### PR TITLE
Fix hint found status not updating automatically

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.jones.aptracker"
         minSdk = 26
         targetSdk = 36
-        versionCode = 38
-        versionName = "1.5.0"
+        versionCode = 39
+        versionName = "1.5.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["appAuthRedirectScheme"] = "com.jones.aptracker"
         buildConfigField(

--- a/android/app/src/main/java/com/jones/aptracker/repository/HistoryRepository.kt
+++ b/android/app/src/main/java/com/jones/aptracker/repository/HistoryRepository.kt
@@ -76,16 +76,20 @@ class HistoryRepository(
     }
 
     // --- HINT REFRESH (Always Full Sync to catch Status Updates) ---
-    suspend fun refreshHintHistory(roomId: Int? = null, includeFound: Boolean) {
+    suspend fun refreshHintHistory(roomId: Int? = null) {
         // We purposefully pass `since = null` here.
         // If we used a timestamp, we would miss hints that were created long ago
         // but were recently marked as "Found", because their creation timestamp didn't change.
+        //
+        // We also always pass `includeFound = true` to ensure the local DB
+        // gets updated with the correct "found" status of existing hints,
+        // even if the user has chosen to hide found hints in the UI.
 
         try {
             val response = if (roomId != null) {
-                apiService.getRoomHintHistory(roomId, since = null, includeFound = includeFound)
+                apiService.getRoomHintHistory(roomId, since = null, includeFound = true)
             } else {
-                apiService.getGlobalHintHistory(since = null, includeFound = includeFound)
+                apiService.getGlobalHintHistory(since = null, includeFound = true)
             }
 
             Log.d("HINT_DEBUG", "Received ${response.hints_for_you.size} 'for_you' and ${response.hints_by_you.size} 'by_you' hints.")

--- a/android/app/src/main/java/com/jones/aptracker/ui/HistoryViewModel.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/HistoryViewModel.kt
@@ -272,7 +272,7 @@ class HistoryViewModel(application: Application) : AndroidViewModel(application)
             // The reactive combine flow above automatically handles the UI update locally!
             // But we launch a silent background request here to fetch any new hints from the API
             viewModelScope.launch {
-                repository.refreshHintHistory(currentRoomId, show)
+                repository.refreshHintHistory(currentRoomId)
             }
         }
     }
@@ -403,8 +403,7 @@ class HistoryViewModel(application: Application) : AndroidViewModel(application)
                 // We launch this in a separate non-blocking way (or just sequentially after flipping the flag)
                 // The UI will update automatically via Flows when this finishes.
                 try {
-                    val includeFound = _showFoundHints.value
-                    repository.refreshHintHistory(currentRoomId, includeFound)
+                    repository.refreshHintHistory(currentRoomId)
                 } catch (e: Exception) {
                     Log.e("HistoryViewModel", "Background hint refresh failed", e)
                     // We don't show an error message to the user here because


### PR DESCRIPTION
Fix hint found status not updating automatically by removing conditional fetching of found hints based on the UI toggle.

## Changes:
- Modified `HistoryRepository.refreshHintHistory` to always use `includeFound = true` when querying the API.
- Updated `HistoryViewModel.kt` to call `refreshHintHistory` without passing the `includeFound` parameter, relying on the repository's new default behavior.
- Ensures the local Room database consistently updates previously unfound hints to found, regardless of the user's current UI filter setting.

---
*PR created automatically by Jules for task [1130470477050870065](https://jules.google.com/task/1130470477050870065) started by @wrjones104*