### PR TITLE
Refactor Android app to use Firebase App Instance ID for push notifications

### DIFF
--- a/alembic/versions/481936e4f29e_rename_android_id_to_device_id.py
+++ b/alembic/versions/481936e4f29e_rename_android_id_to_device_id.py
@@ -1,0 +1,33 @@
+"""rename android_id to device_id
+
+Revision ID: 481936e4f29e
+Revises: bd1c7ba2707e
+Create Date: 2026-03-10 01:08:10.409185
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '481936e4f29e'
+down_revision: Union[str, Sequence[str], None] = 'bd1c7ba2707e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Use raw SQL to rename the column because sqlite batch alter gets tricky with constraints and indexes sometimes
+    with op.get_context().autocommit_block():
+        op.execute('ALTER TABLE devices RENAME COLUMN android_id TO device_id')
+        op.execute('DROP INDEX IF EXISTS ix_devices_android_id')
+        op.execute('CREATE INDEX ix_devices_device_id ON devices (device_id)')
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute('ALTER TABLE devices RENAME COLUMN device_id TO android_id')
+        op.execute('DROP INDEX IF EXISTS ix_devices_device_id')
+        op.execute('CREATE INDEX ix_devices_android_id ON devices (android_id)')


### PR DESCRIPTION
- **Android:**
  - Removed usage of `Settings.Secure.ANDROID_ID` in `AuthViewModel.kt`.
  - Replaced identifier extraction with `FirebaseInstallations.getInstance().id.await()`.
  - Updated `RegisterDeviceRequest` properties in `ApiService.kt` and `AuthViewModel.kt` to use `device_id` rather than `android_id`.
  - Added required `kotlinx.coroutines.tasks.await` import.

- **Backend:**
  - Updated the SQLAlchemy `Device` model in `backend/app/models.py` to use `device_id` instead of `android_id`.
  - Updated the uniqueness constraint (`_user_device_id_uc`).
  - Updated `/devices` POST endpoint in `backend/app/api.py` to extract and operate on `device_id` parameters.
  - Added an Alembic migration script (`481936e4f29e_rename_android_id_to_device_id.py`) using raw SQL to alter the existing columns safely.

---
*PR created automatically by Jules for task [15751925347741212713](https://jules.google.com/task/15751925347741212713) started by @wrjones104*