### PR TITLE
Feature: Transition to Native Discord OAuth Flow

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -27,11 +27,13 @@ android {
         versionCode = 40
         versionName = "1.5.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        manifestPlaceholders["appAuthRedirectScheme"] = "com.jones.aptracker"
+        val discordClientIdValue = localProperties.getProperty("DISCORD_CLIENT_ID", "ABCXYZ")
+        manifestPlaceholders["appAuthRedirectScheme"] = "discord-$discordClientIdValue"
+        manifestPlaceholders["discordClientId"] = discordClientIdValue
         buildConfigField(
             "String",
             "DISCORD_CLIENT_ID",
-            "\"${localProperties.getProperty("DISCORD_CLIENT_ID", "ABCXYZ")}\""
+            "\"$discordClientIdValue\""
         )
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,6 +37,16 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter android:label="Discord Auth Callback">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="discord-${discordClientId}"
+                    android:host="authorize"
+                    android:pathPrefix="/callback" />
+            </intent-filter>
         </activity>
 
         <service

--- a/android/app/src/main/java/com/jones/aptracker/MainActivity.kt
+++ b/android/app/src/main/java/com/jones/aptracker/MainActivity.kt
@@ -229,7 +229,7 @@ class MainActivity : ComponentActivity() {
             Uri.parse("https://discord.com/api/oauth2/token")
         )
         val clientId = BuildConfig.DISCORD_CLIENT_ID
-        val redirectUri = Uri.parse("com.jones.aptracker:/oauth2redirect")
+        val redirectUri = Uri.parse("discord-$clientId://authorize/callback")
         val request = AuthorizationRequest.Builder(
             serviceConfig, clientId, ResponseTypeValues.CODE, redirectUri
         ).setScope("identify").build()
@@ -242,7 +242,8 @@ class MainActivity : ComponentActivity() {
         authViewModel.setLoading(true)
         lifecycleScope.launch {
             try {
-                val redirectUri = "com.jones.aptracker:/oauth2redirect"
+                val clientId = BuildConfig.DISCORD_CLIENT_ID
+                val redirectUri = "discord-$clientId://authorize/callback"
                 val authRequest = AuthRequest(code, redirectUri, codeVerifier)
                 val response = RetrofitClient.instance.exchangeCodeForToken(authRequest)
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -76,8 +76,10 @@ def callback():
         return jsonify({'error': 'Malformed request. Missing required fields.'}), 400
 
     expected_redirect_uri = current_app.config.get('DISCORD_REDIRECT_URI')
-    if redirect_uri != expected_redirect_uri:
-        logging.warning(f"[AUTH_WARN] Redirect URI mismatch. Expected '{expected_redirect_uri}', got '{redirect_uri}'.")
+    expected_native_redirect_uri = f"discord-{current_app.config['DISCORD_CLIENT_ID']}://authorize/callback"
+
+    if redirect_uri not in [expected_redirect_uri, expected_native_redirect_uri]:
+        logging.warning(f"[AUTH_WARN] Redirect URI mismatch. Expected '{expected_redirect_uri}' or '{expected_native_redirect_uri}', got '{redirect_uri}'.")
         return jsonify({'error': 'Redirect URI mismatch.'}), 400
 
     token_url = current_app.config['DISCORD_TOKEN_URL']


### PR DESCRIPTION
This MR introduces a transition from the generic custom URI scheme for OAuth (`com.jones.aptracker:/oauth2redirect`) to a native Discord custom URL scheme (`discord-<CLIENT_ID>://authorize/callback`). This enables the Android system to cleanly identify and route login requests directly to the installed Discord app, providing a significantly smoother user experience since users won't be forced to manually sign in again inside a Chrome Custom Tab.

We maintained the `net.openid.appauth` library which cleanly manages the standard PKCE exchange, we only changed the specific URI scheme used in configuration, and ensuring it correctly syncs between Android building configurations and the Python backend verification logic.

---
*PR created automatically by Jules for task [4453929490385168339](https://jules.google.com/task/4453929490385168339) started by @wrjones104*