### PR TITLE
Fix DatapackageCache exact game name matching constraint

### DIFF
--- a/alembic/versions/e62cbad2759c_update_datapackage_cache_constraint.py
+++ b/alembic/versions/e62cbad2759c_update_datapackage_cache_constraint.py
@@ -1,0 +1,46 @@
+"""update datapackage cache constraint
+
+Revision ID: e62cbad2759c
+Revises: bd1c7ba2707e
+Create Date: 2026-04-15 11:17:52.046581
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e62cbad2759c'
+down_revision: Union[str, Sequence[str], None] = 'bd1c7ba2707e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # SQLite does not support dropping constraints easily, so we usually use batch_alter_table
+    # But first, we need to deduplicate existing rows that would violate the new constraint!
+    # The new constraint is unique on (checksum, entity_type, entity_id). We keep the row with the min(id).
+
+    conn = op.get_bind()
+    conn.execute(sa.text("""
+        DELETE FROM datapackage_cache
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM datapackage_cache
+            GROUP BY checksum, entity_type, entity_id
+        )
+    """))
+
+    with op.batch_alter_table('datapackage_cache', schema=None) as batch_op:
+        batch_op.drop_constraint('_game_checksum_entity_uc', type_='unique')
+        batch_op.create_unique_constraint('_checksum_entity_uc', ['checksum', 'entity_type', 'entity_id'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('datapackage_cache', schema=None) as batch_op:
+        batch_op.drop_constraint('_checksum_entity_uc', type_='unique')
+        batch_op.create_unique_constraint('_game_checksum_entity_uc', ['game', 'checksum', 'entity_type', 'entity_id'])

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -819,12 +819,12 @@ def get_item_history(current_user, room_db_id):
 
         # A. Resolve Item Name (Uses Receiver's Game)
         if receiver_game and rec_checksum:
-            item_name_key = (receiver_game, rec_checksum, 'item', item.item_id)
+            item_name_key = (rec_checksum, 'item', item.item_id)
             cache_keys_to_find.add(item_name_key)
             
         # B. Resolve Location Name (Uses Sender's Game)
         if sender_game and snd_checksum:
-            location_name_key = (sender_game, snd_checksum, 'location', item.location_id)
+            location_name_key = (snd_checksum, 'location', item.location_id)
             cache_keys_to_find.add(location_name_key)
 
         receiver_name = receiver_obj.get('name', f"Player {receiver_id}") if receiver_obj else f"Player {receiver_id}"
@@ -857,21 +857,19 @@ def get_item_history(current_user, room_db_id):
     name_cache_map = {}
     if cache_keys_to_find:
         cache_query = session.query(
-            DatapackageCache.game,
             DatapackageCache.checksum,
             DatapackageCache.entity_type,
             DatapackageCache.entity_id,
             DatapackageCache.entity_name
         ).filter(
             tuple_(
-                DatapackageCache.game,
                 DatapackageCache.checksum,
                 DatapackageCache.entity_type,
                 DatapackageCache.entity_id
             ).in_(cache_keys_to_find)
         )
         name_cache_map = {
-            (c.game, c.checksum, c.entity_type, c.entity_id): c.entity_name
+            (c.checksum, c.entity_type, c.entity_id): c.entity_name
             for c in cache_query.all()
         }
 
@@ -1023,11 +1021,11 @@ def get_global_item_history(current_user):
             location_name_key = None
 
             if receiver_game and rec_checksum:
-                item_name_key = (receiver_game, rec_checksum, 'item', item.item_id)
+                item_name_key = (rec_checksum, 'item', item.item_id)
                 cache_keys_to_find.add(item_name_key)
 
             if sender_game and snd_checksum:
-                location_name_key = (sender_game, snd_checksum, 'location', item.location_id)
+                location_name_key = (snd_checksum, 'location', item.location_id)
                 cache_keys_to_find.add(location_name_key)
 
             history_pre_cache.append({
@@ -1056,14 +1054,12 @@ def get_global_item_history(current_user):
         name_cache_map = {}
         if cache_keys_to_find:
             cache_query = session.query(
-                DatapackageCache.game,
                 DatapackageCache.checksum,
                 DatapackageCache.entity_type,
                 DatapackageCache.entity_id,
                 DatapackageCache.entity_name
             ).filter(
                 tuple_(
-                    DatapackageCache.game,
                     DatapackageCache.checksum,
                     DatapackageCache.entity_type,
                     DatapackageCache.entity_id
@@ -1071,7 +1067,7 @@ def get_global_item_history(current_user):
             )
 
             name_cache_map = {
-                (c.game, c.checksum, c.entity_type, c.entity_id): c.entity_name
+                (c.checksum, c.entity_type, c.entity_id): c.entity_name
                 for c in cache_query.all()
             }
 
@@ -1498,11 +1494,11 @@ def process_hints_for_user(session, user_id, room_db_id=None, since_timestamp=No
         location_name_key = None
 
         if item_owner_game and item_checksum:
-            item_name_key = (item_owner_game, item_checksum, 'item', hint.item_id)
+            item_name_key = (item_checksum, 'item', hint.item_id)
             cache_keys_to_find.add(item_name_key)
             
         if location_owner_game and location_checksum:
-            location_name_key = (location_owner_game, location_checksum, 'location', hint.location_id)
+            location_name_key = (location_checksum, 'location', hint.location_id)
             cache_keys_to_find.add(location_name_key)
 
         temp_hint_data.append({
@@ -1518,21 +1514,19 @@ def process_hints_for_user(session, user_id, room_db_id=None, since_timestamp=No
     name_cache_map = {}
     if cache_keys_to_find:
         cache_query = session.query(
-            DatapackageCache.game,
             DatapackageCache.checksum,
             DatapackageCache.entity_type,
             DatapackageCache.entity_id,
             DatapackageCache.entity_name
         ).filter(
             tuple_(
-                DatapackageCache.game,
                 DatapackageCache.checksum,
                 DatapackageCache.entity_type,
                 DatapackageCache.entity_id
             ).in_(cache_keys_to_find)
         )
         name_cache_map = {
-            (c.game, c.checksum, c.entity_type, c.entity_id): c.entity_name
+            (c.checksum, c.entity_type, c.entity_id): c.entity_name
             for c in cache_query.all()
         }
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -138,7 +138,7 @@ class DatapackageCache(Base):
     entity_type = Column(String, nullable=False)
     entity_id = Column(BigInteger, nullable=False)
     entity_name = Column(String, nullable=False)
-    __table_args__ = (UniqueConstraint('game', 'checksum', 'entity_type', 'entity_id', name='_game_checksum_entity_uc'),)
+    __table_args__ = (UniqueConstraint('checksum', 'entity_type', 'entity_id', name='_checksum_entity_uc'),)
 
 class NotifiedItem(Base):
     __tablename__ = 'notified_items'

--- a/backend/app/poller.py
+++ b/backend/app/poller.py
@@ -372,12 +372,12 @@ def _process_received_items(tracker_data, room_uuid, room_db_id, existing_items_
                 receiver_game = game_map.get(rid, "Unknown")
                 game_checksum = game_checksums.get(receiver_game)
                 if game_checksum:
-                    cache_keys_to_fetch.add((receiver_game, game_checksum, 'item', item_id))
+                    cache_keys_to_fetch.add((game_checksum, 'item', item_id))
 
                 sender_game = game_map.get(send_id, "Unknown")
                 sender_checksum = game_checksums.get(sender_game)
                 if sender_checksum:
-                    cache_keys_to_fetch.add((sender_game, sender_checksum, 'location', loc_id))
+                    cache_keys_to_fetch.add((sender_checksum, 'location', loc_id))
                 
                 new_items_for_notify.append({
                     'item_key_batch': item_key_batch,
@@ -467,9 +467,9 @@ def _process_hints(tracker_data, room_uuid, room_db_id, existing_hints_map, game
                     lo_checksum = game_checksums.get(lo_game)
 
                     if io_checksum:
-                        cache_keys_to_fetch.add((io_game, io_checksum, 'item', item_id))
+                        cache_keys_to_fetch.add((io_checksum, 'item', item_id))
                     if lo_checksum:
-                        cache_keys_to_fetch.add((lo_game, lo_checksum, 'location', loc_id))
+                        cache_keys_to_fetch.add((lo_checksum, 'location', loc_id))
                     
                     new_hints_for_notify.append({
                         'hint_key_batch': hint_key_batch,
@@ -513,8 +513,8 @@ def _resolve_names_and_notify(session, room_db_id, cache_keys_to_fetch, new_item
     if cache_keys_to_fetch:
         logging.debug(f"[POLLER_DEBUG][RoomDBID:{room_db_id}] Fetching {len(cache_keys_to_fetch)} names...")
         try:
-            ids_to_fetch = {k[3] for k in cache_keys_to_fetch}
-            checksums_to_fetch = {k[1] for k in cache_keys_to_fetch}
+            ids_to_fetch = {k[2] for k in cache_keys_to_fetch}
+            checksums_to_fetch = {k[0] for k in cache_keys_to_fetch}
             
             ids_list = list(ids_to_fetch)
             chunk_size = 1000
@@ -523,7 +523,7 @@ def _resolve_names_and_notify(session, room_db_id, cache_keys_to_fetch, new_item
                 id_chunk = ids_list[i:i + chunk_size]
                 
                 results = session.query(
-                    DatapackageCache.game, DatapackageCache.checksum,
+                    DatapackageCache.checksum,
                     DatapackageCache.entity_type, DatapackageCache.entity_id,
                     DatapackageCache.entity_name
                 ).filter(
@@ -531,8 +531,8 @@ def _resolve_names_and_notify(session, room_db_id, cache_keys_to_fetch, new_item
                     DatapackageCache.entity_id.in_(id_chunk)
                 ).all()
 
-                for game, chk, etype, eid, name in results:
-                    key = (game, chk, etype, eid)
+                for chk, etype, eid, name in results:
+                    key = (chk, etype, eid)
                     if key in cache_keys_to_fetch:
                         name_lookup_map[key] = name
 
@@ -543,11 +543,11 @@ def _resolve_names_and_notify(session, room_db_id, cache_keys_to_fetch, new_item
     # 2. Notify Items
     for item_data in new_items_for_notify:
         item_name = name_lookup_map.get(
-            (item_data['receiver_game'], item_data['game_checksum'], 'item', item_data['item_id']), 
+            (item_data['game_checksum'], 'item', item_data['item_id']),
             f"ID {item_data['item_id']}"
         )
         loc_name = name_lookup_map.get(
-            (item_data['sender_game'], item_data['sender_checksum'], 'location', item_data['location_id']),
+            (item_data['sender_checksum'], 'location', item_data['location_id']),
             f"ID {item_data['location_id']}"
         )
         
@@ -696,11 +696,11 @@ def _resolve_names_and_notify(session, room_db_id, cache_keys_to_fetch, new_item
     # 3. Notify Hints
     for hint_data in new_hints_for_notify:
         item_name = name_lookup_map.get(
-            (hint_data['io_game'], hint_data['io_checksum'], 'item', hint_data['item_id']),
+            (hint_data['io_checksum'], 'item', hint_data['item_id']),
             f"ID {hint_data['item_id']}"
         )
         loc_name = name_lookup_map.get(
-            (hint_data['lo_game'], hint_data['lo_checksum'], 'location', hint_data['loc_id']),
+            (hint_data['lo_checksum'], 'location', hint_data['loc_id']),
             f"ID {hint_data['loc_id']}"
         )
         io_id, lo_id = hint_data['io_id'], hint_data['lo_id']


### PR DESCRIPTION
The caching mechanism for the Archipelago Datapackage API previously required the `game` name string to be an exact match when looking up entity names (items or locations). However, if a room uses a custom slot name or a game alias, the string mismatch causes the lookup to fail and fallback to raw numeric IDs. Additionally, some games natively share the same ID for different entities, highlighting the need for robust type and namespace separation. This commit removes `game` from the query constraints in `poller.py` and `api.py` and updates the database schema, relying solely on the combination of `(checksum, entity_type, entity_id)`.

---
*PR created automatically by Jules for task [1340302252814180033](https://jules.google.com/task/1340302252814180033) started by @wrjones104*