### PR TITLE
Extend JWT Token Expiration to 10 Years

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -43,7 +43,7 @@ def create_guest_user():
 
     jwt_id = str(uuid.uuid4())
     issued_at = datetime.now(timezone.utc)
-    expires_at = issued_at + timedelta(days=30) 
+    expires_at = issued_at + timedelta(days=3650)
 
     payload = {
         'user_id': user_id_for_jwt,
@@ -190,7 +190,7 @@ def callback():
 
     jwt_id = str(uuid.uuid4())
     issued_at = datetime.now(timezone.utc)
-    expires_at = issued_at + timedelta(days=30) 
+    expires_at = issued_at + timedelta(days=3650)
 
     payload = {
         'user_id': user_id_for_jwt,


### PR DESCRIPTION
- Updated `backend/app/auth.py` so that JWT tokens issued for guest and Discord users expire after 10 years (3650 days) instead of 30 days.
- Prevents force-logout of active guest users and avoids Discord users needing to re-login unnecessarily.
- Guest account 30-day inactivity pruning (`backend/app/poller.py`) remains intact to continue cleaning up abandoned database entries.

---
*PR created automatically by Jules for task [16801353181724426032](https://jules.google.com/task/16801353181724426032) started by @wrjones104*