### PR TITLE
Remove redundant zlib import in poller.py

### DIFF
--- a/backend/app/poller.py
+++ b/backend/app/poller.py
@@ -1732,7 +1732,6 @@ async def run_room_setup(room_info, loop):
 
                     # 3. Process Item Groups
                     # We use negative IDs for groups to avoid collisions with real item/location IDs
-                    import zlib
                     for g_name in actual_data.get('item_name_groups', {}).keys():
                         # Use a stable hash of the name for a consistent negative ID
                         g_stable_hash = zlib.adler32(g_name.encode('utf-8')) & 0xffffffff


### PR DESCRIPTION
Removed a redundant `import zlib` statement from inside `run_room_setup` in `backend/app/poller.py` since it is already imported at the module level.

---
*PR created automatically by Jules for task [18152116387862549428](https://jules.google.com/task/18152116387862549428) started by @wrjones104*