### PR TITLE
Fix ghost connection for TextClient WebSocket

### DIFF
--- a/android/app/src/main/java/com/jones/aptracker/ui/AppNavigation.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/AppNavigation.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.jones.aptracker.ui.TextClientViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -204,9 +206,11 @@ fun MainNavHost(
         ) { backStackEntry ->
             val roomDbId = backStackEntry.arguments?.getInt("roomDbId")!!
             val slotId = backStackEntry.arguments?.getInt("slotId")!!
+            val textClientViewModel: TextClientViewModel = viewModel(backStackEntry)
             SlotDetailScreen(
                 roomDbId = roomDbId,
                 slotId = slotId,
+                textClientViewModel = textClientViewModel,
                 onBackClick = { navController.popBackStack() },
                 onNavigateToHistory = { roomId, roomAlias, query, player ->
                     val encodedAlias = android.net.Uri.encode(roomAlias)

--- a/android/app/src/main/java/com/jones/aptracker/ui/SlotDetailScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/SlotDetailScreen.kt
@@ -64,7 +64,8 @@ fun SlotDetailScreen(
     slotId: Int,
     onBackClick: () -> Unit,
     onNavigateToHistory: (Int, String, String?, String?) -> Unit,
-    userViewModel: UserViewModel = viewModel()
+    userViewModel: UserViewModel = viewModel(),
+    textClientViewModel: TextClientViewModel = viewModel()
 ) {
     val room by userViewModel.trackedSlotsByRoom.collectAsState()
     val currentRoom = room.find { it.room_db_id == roomDbId }
@@ -90,8 +91,6 @@ fun SlotDetailScreen(
             }
         }
     }
-
-    val textClientViewModel: TextClientViewModel = viewModel()
     val messages by textClientViewModel.messages.collectAsState()
     val connectionStatus by textClientViewModel.connectionStatus.collectAsState()
     val textClientError by textClientViewModel.error.collectAsState()
@@ -136,11 +135,7 @@ fun SlotDetailScreen(
         }
     }
 
-    DisposableEffect(Unit) {
-        onDispose {
-            textClientViewModel.disconnect()
-        }
-    }
+
 
     if (slot == null || currentRoom == null) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {

--- a/android/app/src/main/java/com/jones/aptracker/ui/SlotDetailScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/SlotDetailScreen.kt
@@ -136,6 +136,12 @@ fun SlotDetailScreen(
         }
     }
 
+    DisposableEffect(Unit) {
+        onDispose {
+            textClientViewModel.disconnect()
+        }
+    }
+
     if (slot == null || currentRoom == null) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             CircularProgressIndicator()


### PR DESCRIPTION
Fixes an issue where backing out of the SlotDetailScreen would leave the TextClient WebSocket connection active in the background.

---
*PR created automatically by Jules for task [1814991867631521074](https://jules.google.com/task/1814991867631521074) started by @wrjones104*