### PR TITLE
Add Clear Local History debug option

### DIFF
--- a/android/app/src/main/java/com/jones/aptracker/network/HintDao.kt
+++ b/android/app/src/main/java/com/jones/aptracker/network/HintDao.kt
@@ -33,6 +33,9 @@ interface HintDao {
     @Query("DELETE FROM hints WHERE roomDbId = :roomId AND (itemOwnerId IN (:slotIds) OR locationOwnerId IN (:slotIds))")
     suspend fun deleteHintsForSlots(roomId: Int, slotIds: Set<Int>)
 
+    @Query("DELETE FROM hints")
+    suspend fun deleteAllHints()
+
     @Query("SELECT COUNT(*) FROM hints WHERE roomDbId = :roomId AND isFound = 1")
     suspend fun countFoundHints(roomId: Int): Int
 

--- a/android/app/src/main/java/com/jones/aptracker/network/HistoryDoa.kt
+++ b/android/app/src/main/java/com/jones/aptracker/network/HistoryDoa.kt
@@ -29,4 +29,7 @@ interface HistoryDao {
 
     @Query("DELETE FROM history_items WHERE roomId = :roomId AND slot_id IN (:slotIds)")
     suspend fun deleteHistoryForSlots(roomId: Int, slotIds: Set<Int>)
+
+    @Query("DELETE FROM history_items")
+    suspend fun deleteAllHistory()
 }

--- a/android/app/src/main/java/com/jones/aptracker/repository/HistoryRepository.kt
+++ b/android/app/src/main/java/com/jones/aptracker/repository/HistoryRepository.kt
@@ -154,6 +154,7 @@ class HistoryRepository(
             hintDao.deleteAllHints()
         } catch (e: Exception) {
             Log.e("PRUNING", "Failed to clear all history: ${e.message}", e)
+            throw e
         }
     }
 

--- a/android/app/src/main/java/com/jones/aptracker/repository/HistoryRepository.kt
+++ b/android/app/src/main/java/com/jones/aptracker/repository/HistoryRepository.kt
@@ -147,6 +147,16 @@ class HistoryRepository(
         )
     }
 
+    suspend fun clearAllHistory() {
+        Log.d("PRUNING", "Clearing all history and hints")
+        try {
+            historyDao.deleteAllHistory()
+            hintDao.deleteAllHints()
+        } catch (e: Exception) {
+            Log.e("PRUNING", "Failed to clear all history: ${e.message}", e)
+        }
+    }
+
     suspend fun pruneSlotData(roomId: Int, slotIds: Set<Int>) {
         if (slotIds.isEmpty()) return
         Log.d("PRUNING", "Pruning data for room $roomId, slots: $slotIds")

--- a/android/app/src/main/java/com/jones/aptracker/ui/ProfileScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/ProfileScreen.kt
@@ -76,6 +76,7 @@ fun ProfileScreen(
 
     // State for Delete Dialog
     var showDeleteDialog by remember { mutableStateOf(false) }
+    var showClearHistoryDialog by remember { mutableStateOf(false) }
 
     var showSnoozeDialog by remember { mutableStateOf(false) }
     var now by remember { mutableStateOf(Instant.now()) }
@@ -262,6 +263,22 @@ fun ProfileScreen(
             Spacer(Modifier.height(8.dp))
 
             OutlinedButton(
+                onClick = { showClearHistoryDialog = true },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(8.dp))
+                Text("Clear Local History")
+            }
+
+            Text(
+                "Deletes all locally cached items and hints, forcing a fresh download from the server on next view.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp, bottom = 24.dp)
+            )
+
+            OutlinedButton(
                 onClick = { userViewModel.sendTestNotification() },
                 modifier = Modifier.fillMaxWidth()
             ) {
@@ -277,6 +294,27 @@ fun ProfileScreen(
                 modifier = Modifier.padding(top = 8.dp, bottom = 24.dp)
             )
         }
+    }
+
+    if (showClearHistoryDialog) {
+        AlertDialog(
+            onDismissRequest = { showClearHistoryDialog = false },
+            title = { Text("Clear Local History?") },
+            text = { Text("This will delete all locally cached items and hints. They will be re-downloaded from the server next time you view the history screen.") },
+            confirmButton = {
+                Button(onClick = {
+                    showClearHistoryDialog = false
+                    userViewModel.clearLocalHistory()
+                }) {
+                    Text("Clear")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearHistoryDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
     }
 
     // --- Delete Confirmation Dialog ---

--- a/android/app/src/main/java/com/jones/aptracker/ui/UserViewModel.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/UserViewModel.kt
@@ -16,6 +16,8 @@ import com.jones.aptracker.network.SnoozeRequest
 import com.jones.aptracker.network.AutocompleteOption
 import com.jones.aptracker.network.SlotItemThreshold
 import com.jones.aptracker.network.UpdateThresholdRequest
+import com.jones.aptracker.database.AppDatabase
+import com.jones.aptracker.repository.HistoryRepository
 import com.jones.aptracker.repository.UserRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -32,10 +34,10 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
     // --- Dependencies ---
     private val settingsManager = SettingsManager(application)
     private val userRepository = UserRepository(RetrofitClient.instance)
-    private val historyRepository = com.jones.aptracker.repository.HistoryRepository(
+    private val historyRepository = HistoryRepository(
         RetrofitClient.instance,
-        com.jones.aptracker.database.AppDatabase.getInstance(application).historyDao(),
-        com.jones.aptracker.database.AppDatabase.getInstance(application).hintDao()
+        AppDatabase.getInstance(application).historyDao(),
+        AppDatabase.getInstance(application).hintDao()
     )
 
     // Quick access to SharedPreferences for UI state (like sort order)

--- a/android/app/src/main/java/com/jones/aptracker/ui/UserViewModel.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/UserViewModel.kt
@@ -32,6 +32,11 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
     // --- Dependencies ---
     private val settingsManager = SettingsManager(application)
     private val userRepository = UserRepository(RetrofitClient.instance)
+    private val historyRepository = com.jones.aptracker.repository.HistoryRepository(
+        RetrofitClient.instance,
+        com.jones.aptracker.database.AppDatabase.getInstance(application).historyDao(),
+        com.jones.aptracker.database.AppDatabase.getInstance(application).hintDao()
+    )
 
     // Quick access to SharedPreferences for UI state (like sort order)
     private val uiPrefs by lazy {
@@ -490,6 +495,18 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
                     }
                 }
                 _integrationMessage.value = "All snoozes cleared."
+            }
+        }
+    }
+
+    fun clearLocalHistory() {
+        viewModelScope.launch {
+            try {
+                historyRepository.clearAllHistory()
+                _integrationMessage.value = "Local history cleared."
+            } catch (e: Exception) {
+                _errorMessage.value = "Failed to clear local history."
+                e.printStackTrace()
             }
         }
     }


### PR DESCRIPTION
Adds a "Clear Local History" button to the Debug section of the Profile Screen. It deletes all locally cached items and hints, triggering a fresh download from the server on the next pull.

---
*PR created automatically by Jules for task [6119552890252209353](https://jules.google.com/task/6119552890252209353) started by @wrjones104*