### PR TITLE
docs: update docs for guest mode and SSRF protections

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -52,14 +52,14 @@ The system consists of two main parts:
 *   **Asynchronous Processing:** The `poller.py` script uses `asyncio` and `aiohttp` for high-concurrency polling of multiple Archipelago rooms.
 *   **Authentication:**
     *   **Discord OAuth2:** Users log in via Discord.
-    *   **JWT:** The backend issues JWTs for API access after Discord auth.
+    *   **JWT:** The backend issues JWTs for API access after Discord auth (90 days expiration) or for guest accounts (730 days expiration).
     *   **Guest Mode:** Supports anonymous guest accounts.
 *   **Push Notifications:** Firebase Cloud Messaging (FCM) via `firebase-admin` SDK.
 *   **Integrations:** "Cheese Tracker" integration allows users to sync their tracked rooms from an external service. API keys are stored encrypted.
 
 ### Database Schema (Key Models)
 
-*   `User`: Stores Discord ID, preferences, and encryption keys.
+*   `User`: Stores Discord ID, preferences, and encryption keys. Inactive guest accounts are pruned after 30 days.
 *   `TrackedRoom`: Represents a single Archipelago game room (URL, tracker ID).
 *   `UserRoomSubscription`: Links a User to a TrackedRoom with an alias.
 *   `UserTrackedSlot`: Represents a specific player slot a User wants to watch within a Room.
@@ -73,6 +73,7 @@ The system consists of two main parts:
 2.  **Polling Logic:** The `poller.py` is complex. It manages concurrent setups, regular polling, and "Cheese" polling. It handles "backfilling" history for new subscriptions to avoid notification spam.
 3.  **No Tests:** The project currently lacks a formal test suite. Changes should be verified carefully, preferably by running the backend locally.
 4.  **Frontend/Backend Sync:** Changes to API response formats in `backend/app/api.py` usually require corresponding updates in the Android app (specifically the Retrofit interfaces).
+5.  **SSRF Protection:** The backend implements programmatic SSRF protections (`SSRFProtectedTCPConnector` and `SSRFProtectedResolver` in `utils.py`) to block connections to private, loopback, and metadata IPs during external requests.
 
 ## "Gotchas"
 

--- a/backend/SECURITY.md
+++ b/backend/SECURITY.md
@@ -13,14 +13,13 @@ This document outlines the security measures in place to protect user data and e
 - **Secure Signing Algorithm**: JWTs are signed using the HMAC-SHA256 algorithm, which is a strong and widely-used symmetric signing algorithm.
 - **JTI (JWT ID) Claim**: Each JWT is issued with a unique `jti` claim, which is used to prevent token replay attacks.
 - **JWT Blocklist**: A JWT blocklist is implemented to allow for the immediate revocation of tokens in the event of a security incident. When a user logs out or deletes their account, their token's `jti` is added to the blocklist, rendering it unusable.
-- **Short-Lived Tokens**: JWTs have a 30-day expiration, which limits the window of opportunity for an attacker to use a stolen token.
+- **Token Expiration**: JWTs issued to Discord users have a 90-day expiration, while tokens for anonymous guest users have a 730-day expiration.
 
 ## API Security
 
 ### Input Validation
 - **Strict Input Validation**: All incoming data is strictly validated to ensure that it is of the correct type, length, and format. This prevents a wide range of attacks, including SQL injection, Cross-Site Scripting (XSS), and buffer overflows.
-- **Hostname Whitelist**: The `add_room` endpoint uses a hostname whitelist to restrict the servers that the application can connect to. This prevents Server-Side Request Forgery (SSRF) attacks, where an attacker could force the server to make requests to internal resources.
-- **IP Address Blacklist**: The `add_room` endpoint also uses an IP address blacklist to prevent users from adding rooms with IP addresses. This further mitigates the risk of SSRF attacks.
+- **Programmatic SSRF Protection**: The application uses `aiohttp`'s `SSRFProtectedTCPConnector` and `SSRFProtectedResolver` to block connections to private, loopback, and metadata IPs during external requests (like polling rooms). This robustly prevents Server-Side Request Forgery (SSRF) attacks, ensuring the server cannot be forced to access internal network resources.
 
 ### Insecure Deserialization
 - **Safe JSON Parsing**: All JSON data is parsed using the `json.loads` function, which is safe from insecure deserialization vulnerabilities. The application never uses `pickle` or other unsafe deserialization libraries.

--- a/readme.md
+++ b/readme.md
@@ -6,13 +6,14 @@ Archipelago Alerts (formerly AP Tracker) is a tool for tracking Archipelago mult
 
 This project was built to solve a simple problem: wanting to know when important things happen in an Archipelago game without having to constantly watch a tracker website or be at your computer.
 
-The app uses Discord for authentication. The backend service polls rooms you've added, and the Android app provides a clean interface for managing your tracked rooms, setting notification preferences, and viewing event history. When a significant event occurs, the backend sends a push notification via Firebase Cloud Messaging directly to your phone.
+The app uses Discord for authentication, but also supports an anonymous guest mode. The backend service polls rooms you've added, and the Android app provides a clean interface for managing your tracked rooms, setting notification preferences, and viewing event history. When a significant event occurs, the backend sends a push notification via Firebase Cloud Messaging directly to your phone.
 
 ---
 
 ### Key Features ✨
 
 * **Discord Authentication:** Securely log in using your existing Discord account via OAuth 2.0.
+* **Guest Mode:** Try the application anonymously without linking a Discord account.
 * **Room Management:** Easily add, rename, and remove Archipelago rooms you want to track.
 * **Player Selection:** Choose exactly which players in a room you want to receive notifications for.
 * **Per-Slot Preferences:** Fine-tune your notifications for *each specific player*, overriding your global defaults.


### PR DESCRIPTION
Updates readme.md, LLM.md, and backend/SECURITY.md to reflect recent feature additions and security hardening:
- Documented Guest Mode functionality and account pruning
- Clarified JWT token expirations (90 days for Discord, 730 days for guest)
- Replaced outdated whitelist/blacklist SSRF mitigation docs with the new programmatic aiohttp connector protection strategy

---
*PR created automatically by Jules for task [13285678306859605870](https://jules.google.com/task/13285678306859605870) started by @wrjones104*