### PR TITLE
Add date format preset preference

### DIFF
--- a/android/app/src/main/java/com/jones/aptracker/data/SettingsManager.kt
+++ b/android/app/src/main/java/com/jones/aptracker/data/SettingsManager.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -18,6 +19,7 @@ class SettingsManager(context: Context) {
     companion object {
         val CHEESE_AUTO_SYNC_KEY = booleanPreferencesKey("cheese_auto_sync")
         val IS_CHEESE_CONNECTED_KEY = booleanPreferencesKey("is_cheese_connected")
+        val DATE_FORMAT_PRESET_KEY = stringPreferencesKey("date_format_preset")
     }
 
     /**
@@ -39,6 +41,15 @@ class SettingsManager(context: Context) {
         }
 
     /**
+     * A flow that emits the current date format preset.
+     * It defaults to 'SYSTEM_DEFAULT' if not set.
+     */
+    val dateFormatPreset: Flow<String> = dataStore.data
+        .map { preferences ->
+            preferences[DATE_FORMAT_PRESET_KEY] ?: "SYSTEM_DEFAULT"
+        }
+
+    /**
      * Saves the new auto-sync preference.
      */
     suspend fun setAutoSync(isEnabled: Boolean) {
@@ -53,6 +64,15 @@ class SettingsManager(context: Context) {
     suspend fun setCheeseConnected(isConnected: Boolean) {
         dataStore.edit { preferences ->
             preferences[IS_CHEESE_CONNECTED_KEY] = isConnected
+        }
+    }
+
+    /**
+     * Saves the new date format preset preference.
+     */
+    suspend fun setDateFormatPreset(preset: String) {
+        dataStore.edit { preferences ->
+            preferences[DATE_FORMAT_PRESET_KEY] = preset
         }
     }
 }

--- a/android/app/src/main/java/com/jones/aptracker/ui/HistoryScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/HistoryScreen.kt
@@ -137,6 +137,9 @@ fun HistoryContent(
 
     val roomNames by historyViewModel.roomNames.collectAsState()
 
+    val dateFormatPresetKey by userViewModel.dateFormatPreset.collectAsState()
+    val dateFormatPreset = remember(dateFormatPresetKey) { DateFormatPreset.fromKey(dateFormatPresetKey) }
+
     var selectedItem by remember { mutableStateOf<HistoryItem?>(null) }
     var selectedHint by remember { mutableStateOf<HintEntity?>(null) }
     var showFilterSheet by remember { mutableStateOf(false) }
@@ -225,6 +228,7 @@ fun HistoryContent(
                         0 -> ItemHistoryTab(
                             historyViewModel = historyViewModel,
                             searchQuery = searchQuery,
+                            dateFormatPreset = dateFormatPreset,
                             onItemClick = { selectedItem = it },
                             showRoomFilter = showRoomFilter,
                             showIgnoredItems = showIgnoredItems,
@@ -233,6 +237,7 @@ fun HistoryContent(
                         1 -> HintHistoryTab(
                             historyViewModel = historyViewModel,
                             searchQuery = searchQuery,
+                            dateFormatPreset = dateFormatPreset,
                             onHintClick = { selectedHint = it },
                             showRoomFilter = showRoomFilter,
                             showIgnoredItems = showIgnoredItems,
@@ -280,6 +285,7 @@ fun HistoryContent(
             title = "Snooze Player",
             currentSnoozeUntil = null,
             activeSnoozeDetails = emptyList(), // Pass empty list if not using details here
+            dateFormatPreset = dateFormatPreset,
             onDismiss = { showSnoozeDialogForSlot = null },
             onSnoozeSelected = { minutes ->
                 userViewModel.setSlotSnooze(snoozeRoomId, snoozeSlotId, minutes)
@@ -296,6 +302,7 @@ fun HistoryContent(
             HistoryDetailSheet(
                 item = selectedItem!!,
                 roomName = itemRoomName,
+                dateFormatPreset = dateFormatPreset,
                 onOpenTracker = {
                     val cleanHost = (selectedItem!!.host?.takeIf { it.isNotBlank() } ?: "archipelago.gg")
                         .removePrefix("https://").removePrefix("http://")
@@ -530,14 +537,14 @@ fun HistoryFilterSheet(
 fun HistoryDetailSheet(
     item: HistoryItem,
     roomName: String,
+    dateFormatPreset: DateFormatPreset,
     onOpenTracker: () -> Unit,
     onIgnoreItem: (String?) -> Unit,
     onSnoozePlayer: () -> Unit,
     onViewSlot: (() -> Unit)? = null
 ) {
-    val formatter = remember {
-        DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
-            .withZone(ZoneId.systemDefault())
+    val formatter = remember(dateFormatPreset) {
+        dateFormatPreset.getFormatter(isDetail = true)
     }
 
     fun formatName(name: String, alias: String?): String {
@@ -712,6 +719,7 @@ fun CompactDetailItem(label: String, value: String) {
 fun ItemHistoryTab(
     historyViewModel: HistoryViewModel,
     searchQuery: String,
+    dateFormatPreset: DateFormatPreset,
     onItemClick: (HistoryItem) -> Unit,
     showRoomFilter: Boolean,
     showIgnoredItems: Boolean,
@@ -733,9 +741,8 @@ fun ItemHistoryTab(
     val archivedRoomIds by historyViewModel.archivedRoomIds.collectAsState()
     val availableRooms by historyViewModel.availableRooms.collectAsState()
 
-    val formatter = remember {
-        DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
-            .withZone(ZoneId.systemDefault())
+    val formatter = remember(dateFormatPreset) {
+        dateFormatPreset.getFormatter(isDetail = false)
     }
 
     val isDark = isSystemInDarkTheme()
@@ -1130,6 +1137,7 @@ fun RoomFilterChip(
 fun HintHistoryTab(
     historyViewModel: HistoryViewModel,
     searchQuery: String,
+    dateFormatPreset: DateFormatPreset,
     onHintClick: (HintEntity) -> Unit,
     showRoomFilter: Boolean,
     showIgnoredItems: Boolean,
@@ -1153,9 +1161,8 @@ fun HintHistoryTab(
     val archivedRoomIds by historyViewModel.archivedRoomIds.collectAsState()
     val availableRooms by historyViewModel.availableRooms.collectAsState()
 
-    val formatter = remember {
-        DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
-            .withZone(ZoneId.systemDefault())
+    val formatter = remember(dateFormatPreset) {
+        dateFormatPreset.getFormatter(isDetail = false)
     }
 
     var isForYouExpanded by rememberSaveable { mutableStateOf(true) }

--- a/android/app/src/main/java/com/jones/aptracker/ui/ProfileScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/ProfileScreen.kt
@@ -74,6 +74,9 @@ fun ProfileScreen(
     val userProfile by userViewModel.userProfile.collectAsState()
     val isAutoSyncEnabled by userViewModel.isAutoSyncEnabled.collectAsState()
 
+    val dateFormatPresetKey by userViewModel.dateFormatPreset.collectAsState()
+    val dateFormatPreset = remember(dateFormatPresetKey) { DateFormatPreset.fromKey(dateFormatPresetKey) }
+
     // State for Delete Dialog
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showClearHistoryDialog by remember { mutableStateOf(false) }
@@ -101,6 +104,7 @@ fun ProfileScreen(
             title = "Global Snooze",
             currentSnoozeUntil = if (isGlobalSnoozeActive) globalSnoozeRaw else null,
             activeSnoozeDetails = emptyList(),
+            dateFormatPreset = dateFormatPreset,
             onDismiss = { showSnoozeDialog = false },
             onSnoozeSelected = { minutes ->
                 userViewModel.setGlobalSnooze(minutes)
@@ -163,7 +167,7 @@ fun ProfileScreen(
             Spacer(Modifier.height(32.dp))
 
             val snoozeSubtitle = userProfile?.global_snooze_until?.let { snoozeTime ->
-                "Active until ${formatIsoDate(snoozeTime)}"
+                "Active until ${formatIsoDate(snoozeTime, dateFormatPreset)}"
             } ?: "Silence all notifications temporarily"
 
             // --- Menu Options ---
@@ -172,7 +176,7 @@ fun ProfileScreen(
                 icon = Icons.Default.NotificationsPaused,
                 title = "Snooze All Notifications",
                 subtitle = if (isGlobalSnoozeActive) {
-                    "Active until ${formatIsoDate(globalSnoozeRaw ?: "")}"
+                    "Active until ${formatIsoDate(globalSnoozeRaw ?: "", dateFormatPreset)}"
                 } else {
                     null
                 },

--- a/android/app/src/main/java/com/jones/aptracker/ui/ProfileScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/ProfileScreen.kt
@@ -176,7 +176,7 @@ fun ProfileScreen(
                 icon = Icons.Default.NotificationsPaused,
                 title = "Snooze All Notifications",
                 subtitle = if (isGlobalSnoozeActive) {
-                    "Active until ${formatIsoDate(globalSnoozeRaw ?: "", dateFormatPreset)}"
+                    "Active until ${formatIsoDate(globalSnoozeRaw!!, dateFormatPreset)}"
                 } else {
                     null
                 },

--- a/android/app/src/main/java/com/jones/aptracker/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/SettingsScreen.kt
@@ -224,16 +224,8 @@ fun SettingsScreen(
                                     onDismissRequest = { dropdownExpanded = false }
                                 ) {
                                     DateFormatPreset.values().forEach { preset ->
-                                        val displayLabel = when (preset) {
-                                            DateFormatPreset.SYSTEM_DEFAULT -> "System Default"
-                                            DateFormatPreset.ISO_LIKE -> "ISO (2026-06-08 12:05)"
-                                            DateFormatPreset.US_12H -> "US (06/08/2026 12:05 PM)"
-                                            DateFormatPreset.EU_24H -> "Europe (08/06/2026 12:05)"
-                                            DateFormatPreset.DE_24H -> "Germany (08.06.2026 12:05)"
-                                            DateFormatPreset.FRIENDLY_12H -> "Friendly (Jun 8, 2026 12:05 PM)"
-                                        }
                                         DropdownMenuItem(
-                                            text = { Text(displayLabel) },
+                                            text = { Text(preset.label) },
                                             onClick = {
                                                 userViewModel.setDateFormatPreset(preset.key)
                                                 dropdownExpanded = false

--- a/android/app/src/main/java/com/jones/aptracker/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/SettingsScreen.kt
@@ -10,13 +10,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -27,7 +31,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -187,6 +193,61 @@ fun SettingsScreen(
                             checked = profile.use_condensed_messages_default,
                             onCheckedChange = { userViewModel.updateGlobalPreferences(useCondensed = it) }
                         )
+                        HorizontalDivider()
+
+                        // Date Format Setting
+                        var dropdownExpanded by remember { mutableStateOf(false) }
+                        val dateFormatPresetKey by userViewModel.dateFormatPreset.collectAsState()
+                        val currentPreset = remember(dateFormatPresetKey) { DateFormatPreset.fromKey(dateFormatPresetKey) }
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text("Date format", style = MaterialTheme.typography.bodyLarge)
+                                Text(
+                                    text = "Choose how timestamps are displayed.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            Box {
+                                OutlinedButton(onClick = { dropdownExpanded = true }) {
+                                    Text(currentPreset.label)
+                                }
+                                DropdownMenu(
+                                    expanded = dropdownExpanded,
+                                    onDismissRequest = { dropdownExpanded = false }
+                                ) {
+                                    DateFormatPreset.values().forEach { preset ->
+                                        val displayLabel = when (preset) {
+                                            DateFormatPreset.SYSTEM_DEFAULT -> "System Default"
+                                            DateFormatPreset.ISO_LIKE -> "ISO (2026-06-08 12:05)"
+                                            DateFormatPreset.US_12H -> "US (06/08/2026 12:05 PM)"
+                                            DateFormatPreset.EU_24H -> "Europe (08/06/2026 12:05)"
+                                            DateFormatPreset.DE_24H -> "Germany (08.06.2026 12:05)"
+                                            DateFormatPreset.FRIENDLY_12H -> "Friendly (Jun 8, 2026 12:05 PM)"
+                                        }
+                                        DropdownMenuItem(
+                                            text = { Text(displayLabel) },
+                                            onClick = {
+                                                userViewModel.setDateFormatPreset(preset.key)
+                                                dropdownExpanded = false
+                                            },
+                                            trailingIcon = {
+                                                if (preset == currentPreset) {
+                                                    Icon(Icons.Default.Check, null)
+                                                }
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+                        }
 
                         // Bottom padding
                         Box(Modifier.padding(bottom = 32.dp))

--- a/android/app/src/main/java/com/jones/aptracker/ui/SnoozeDialog.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/SnoozeDialog.kt
@@ -27,6 +27,7 @@ fun SnoozeDialog(
     title: String = "Snooze Notifications",
     currentSnoozeUntil: String? = null,
     activeSnoozeDetails: List<String> = emptyList(),
+    dateFormatPreset: DateFormatPreset = DateFormatPreset.SYSTEM_DEFAULT,
     onDismiss: () -> Unit,
     onSnoozeSelected: (Int) -> Unit
 ) {
@@ -37,7 +38,7 @@ fun SnoozeDialog(
             Column {
                 // 1. Show Global Snooze Status
                 if (currentSnoozeUntil != null) {
-                    Text("Global Snooze active until: ${formatIsoDate(currentSnoozeUntil)}")
+                    Text("Global Snooze active until: ${formatIsoDate(currentSnoozeUntil, dateFormatPreset)}")
                     Spacer(Modifier.height(16.dp))
                 }
 
@@ -91,7 +92,7 @@ fun SnoozeOptionButton(text: String, minutes: Int, onSelect: (Int) -> Unit) {
     }
 }
 
-fun formatIsoDate(isoString: String): String {
+fun formatIsoDate(isoString: String, dateFormatPreset: DateFormatPreset = DateFormatPreset.SYSTEM_DEFAULT): String {
     return try {
         // 1. Parse the incoming string.
         val cleanedString = isoString.replace("Z", "")
@@ -104,7 +105,7 @@ fun formatIsoDate(isoString: String): String {
         val localTime = utcTime.withZoneSameInstant(ZoneId.systemDefault())
 
         // 4. Format nicely
-        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)
+        val formatter = dateFormatPreset.getFormatter(isDetail = true)
 
         localTime.format(formatter)
     } catch (e: Exception) {

--- a/android/app/src/main/java/com/jones/aptracker/ui/UiUtils.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/UiUtils.kt
@@ -6,13 +6,20 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
-enum class DateFormatPreset(val key: String, val label: String, val pattern: String?) {
+enum class DateFormatPreset(val key: String, val description: String, val pattern: String?) {
     SYSTEM_DEFAULT("SYSTEM_DEFAULT", "System Default", null),
-    ISO_LIKE("ISO_LIKE", "2026-06-08 12:05", "yyyy-MM-dd HH:mm"),
-    US_12H("US_12H", "06/08/2026 12:05 PM", "MM/dd/yyyy h:mm a"),
-    EU_24H("EU_24H", "08/06/2026 12:05", "dd/MM/yyyy HH:mm"),
-    DE_24H("DE_24H", "08.06.2026 12:05", "dd.MM.yyyy HH:mm"),
-    FRIENDLY_12H("FRIENDLY_12H", "Jun 8, 2026 12:05 PM", "MMM d, yyyy h:mm a");
+    ISO_LIKE("ISO_LIKE", "ISO", "yyyy-MM-dd HH:mm"),
+    US_12H("US_12H", "US", "MM/dd/yyyy h:mm a"),
+    EU_24H("EU_24H", "Europe", "dd/MM/yyyy HH:mm"),
+    DE_24H("DE_24H", "Germany", "dd.MM.yyyy HH:mm"),
+    FRIENDLY_12H("FRIENDLY_12H", "Friendly", "MMM d, yyyy h:mm a");
+
+    val label: String
+        get() {
+            val sample = java.time.ZonedDateTime.of(2026, 6, 8, 12, 5, 0, 0, java.time.ZoneId.systemDefault())
+            val formatted = sample.format(getFormatter(isDetail = true))
+            return if (this == SYSTEM_DEFAULT) description else "$description ($formatted)"
+        }
 
     fun getFormatter(isDetail: Boolean = false): DateTimeFormatter {
         return if (pattern != null) {

--- a/android/app/src/main/java/com/jones/aptracker/ui/UiUtils.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/UiUtils.kt
@@ -2,6 +2,34 @@ package com.jones.aptracker.ui
 
 import com.jones.aptracker.network.Room
 import com.jones.aptracker.network.RoomEntity
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+enum class DateFormatPreset(val key: String, val label: String, val pattern: String?) {
+    SYSTEM_DEFAULT("SYSTEM_DEFAULT", "System Default", null),
+    ISO_LIKE("ISO_LIKE", "2026-06-08 12:05", "yyyy-MM-dd HH:mm"),
+    US_12H("US_12H", "06/08/2026 12:05 PM", "MM/dd/yyyy h:mm a"),
+    EU_24H("EU_24H", "08/06/2026 12:05", "dd/MM/yyyy HH:mm"),
+    DE_24H("DE_24H", "08.06.2026 12:05", "dd.MM.yyyy HH:mm"),
+    FRIENDLY_12H("FRIENDLY_12H", "Jun 8, 2026 12:05 PM", "MMM d, yyyy h:mm a");
+
+    fun getFormatter(isDetail: Boolean = false): DateTimeFormatter {
+        return if (pattern != null) {
+            DateTimeFormatter.ofPattern(pattern).withZone(ZoneId.systemDefault())
+        } else {
+            val style = if (isDetail) FormatStyle.MEDIUM else FormatStyle.SHORT
+            DateTimeFormatter.ofLocalizedDateTime(style).withZone(ZoneId.systemDefault())
+        }
+    }
+
+    companion object {
+        fun fromKey(key: String?): DateFormatPreset {
+            return values().find { it.key == key } ?: SYSTEM_DEFAULT
+        }
+    }
+}
+
 
 fun getDisplayName(originalName: String?, alias: String?, useCondensed: Boolean): String {
     val safeOriginal = originalName ?: "Unknown"

--- a/android/app/src/main/java/com/jones/aptracker/ui/UserViewModel.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/UserViewModel.kt
@@ -71,6 +71,12 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
         true
     )
 
+    val dateFormatPreset = settingsManager.dateFormatPreset.stateIn(
+        viewModelScope,
+        SharingStarted.Eagerly,
+        "SYSTEM_DEFAULT"
+    )
+
     // --- Ignore List & Sorting State ---
     private val _ignoreList = MutableStateFlow<List<IgnoreItem>>(emptyList())
     val ignoreList = _ignoreList.asStateFlow()
@@ -95,6 +101,12 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
     fun setAutoSync(isEnabled: Boolean) {
         viewModelScope.launch {
             settingsManager.setAutoSync(isEnabled)
+        }
+    }
+
+    fun setDateFormatPreset(preset: String) {
+        viewModelScope.launch {
+            settingsManager.setDateFormatPreset(preset)
         }
     }
 


### PR DESCRIPTION
Add date format preset preference to SettingsManager and utilize it in HistoryScreen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-facing "Date format" setting with multiple presets (including System Default).
  * Users can select preferred date/time format from Settings; selection persists.
  * App-wide date/time displays (History, Profile, dialogs, snooze UI, etc.) now honor the selected preset.
  * Preset labels show sample formatting to help selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->