### PR TITLE
Update Markdown Documentation (Readme, LLM, Security)

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -42,7 +42,7 @@ The system consists of two main parts:
 *   **Networking:** Retrofit for REST API requests with OkHttp interceptors (`AuthInterceptor.kt`) for handling JWT authentication headers.
 *   **Local Storage:**
     *   Room Database (`androidx.room`) for caching application data locally.
-    *   `EncryptedSharedPreferences` for securely storing JWT authentication tokens (`TokenManager.kt`).
+    *   `EncryptedSharedPreferences` for securely storing JWT authentication tokens (`TokenManager.kt`). This file is explicitly excluded from Android Auto Backup to prevent crash loops from restored un-decryptable preferences.
 *   **Authentication:** Integrates with Discord OAuth2 using the `net.openid.appauth` library via deep-linking schemes.
 
 ### Backend
@@ -52,8 +52,8 @@ The system consists of two main parts:
 *   **Asynchronous Processing:** The `poller.py` script uses `asyncio` and `aiohttp` for high-concurrency polling of multiple Archipelago rooms.
 *   **Authentication:**
     *   **Discord OAuth2:** Users log in via Discord.
-    *   **JWT:** The backend issues JWTs for API access after Discord auth.
-    *   **Guest Mode:** Supports anonymous guest accounts.
+    *   **JWT:** The backend issues JWTs for API access after Discord auth. Tokens expire after 90 days for Discord users and 730 days for guest accounts.
+    *   **Guest Mode:** Supports anonymous guest accounts, which are automatically pruned after 30 days of inactivity.
 *   **Push Notifications:** Firebase Cloud Messaging (FCM) via `firebase-admin` SDK.
 *   **Integrations:** "Cheese Tracker" integration allows users to sync their tracked rooms from an external service. API keys are stored encrypted. Slot claims and unclaims are synced bidirectionally; ownership conflicts (both authenticated and unauthenticated) are strictly validated to prevent claim clobbering, and slot collisions immediately trigger local untracking and FCM push notifications.
 
@@ -83,6 +83,8 @@ The system consists of two main parts:
 *   **Polling:** The poller uses a "Supervisor" pattern to manage tasks. It has self-healing logic for "Pending" rooms that turn into real rooms.
 *   **Privacy:** We strictly avoid storing sensitive Discord info (email/pass). We only store ID, username, and avatar hash.
 *   **Cheese Tracker Claim Checking:** Unauthenticated claims on Cheese Tracker leave `claimed_by_ct_user_id` as `None` but populate `discord_username` (which shows as `effective_discord_username` on GET requests). Checking for claim conflicts requires checking both for authenticated ID mismatches and unauthenticated Discord username mismatches.
+*   **SSRF Protections:** When testing locally against private/loopback IPs, ensure `FLASK_ENV='development'` is set, or the `SSRFProtectedTCPConnector` and `SSRFProtectedResolver` will aggressively block backend outgoing connections to those addresses.
+*   **aiohttp connector_owner:** When instantiating `aiohttp.ClientSession` directly instead of using the global session from the poller context, always explicitly pass `connector_owner=True` to avoid connection pooling warnings/resource leaks.
 
 ## LLM Maintenance Directive
 

--- a/backend/SECURITY.md
+++ b/backend/SECURITY.md
@@ -13,14 +13,14 @@ This document outlines the security measures in place to protect user data and e
 - **Secure Signing Algorithm**: JWTs are signed using the HMAC-SHA256 algorithm, which is a strong and widely-used symmetric signing algorithm.
 - **JTI (JWT ID) Claim**: Each JWT is issued with a unique `jti` claim, which is used to prevent token replay attacks.
 - **JWT Blocklist**: A JWT blocklist is implemented to allow for the immediate revocation of tokens in the event of a security incident. When a user logs out or deletes their account, their token's `jti` is added to the blocklist, rendering it unusable.
-- **Short-Lived Tokens**: JWTs have a 30-day expiration, which limits the window of opportunity for an attacker to use a stolen token.
+- **Token Expiration**: JWTs have a 90-day expiration for Discord users and a 730-day expiration for anonymous guest accounts, balancing user convenience with the window of opportunity for an attacker to use a stolen token.
+- **Android Backup Exclusion**: The Android app explicitly excludes the `EncryptedSharedPreferences` file storing authentication tokens from Android Auto Backup to prevent issues during device transfers.
 
 ## API Security
 
 ### Input Validation
 - **Strict Input Validation**: All incoming data is strictly validated to ensure that it is of the correct type, length, and format. This prevents a wide range of attacks, including SQL injection, Cross-Site Scripting (XSS), and buffer overflows.
-- **Hostname Whitelist**: The `add_room` endpoint uses a hostname whitelist to restrict the servers that the application can connect to. This prevents Server-Side Request Forgery (SSRF) attacks, where an attacker could force the server to make requests to internal resources.
-- **IP Address Blacklist**: The `add_room` endpoint also uses an IP address blacklist to prevent users from adding rooms with IP addresses. This further mitigates the risk of SSRF attacks.
+- **SSRF Protection**: Application endpoints use `SSRFProtectedTCPConnector` and `SSRFProtectedResolver` to prevent Server-Side Request Forgery (SSRF) attacks. This blocks connections to private, loopback, and metadata IPs during external room connections (unless bypassed in 'development' mode).
 
 ### Insecure Deserialization
 - **Safe JSON Parsing**: All JSON data is parsed using the `json.loads` function, which is safe from insecure deserialization vulnerabilities. The application never uses `pickle` or other unsafe deserialization libraries.
@@ -38,6 +38,9 @@ This document outlines the security measures in place to protect user data and e
 ### Database Security
 - **Row-Level Locking**: The application uses row-level locking when querying the user table to prevent race conditions and ensure data integrity.
 - **Parameterized Queries**: The application uses parameterized queries to prevent SQL injection attacks.
+
+## Data Retention
+- **Guest Account Pruning**: Inactive anonymous guest accounts (and their associated data) are automatically pruned after 30 days of inactivity to minimize unnecessary data retention.
 
 ## Best Practices
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,9 @@ The app uses Discord for authentication. The backend service polls rooms you've 
 ### Key Features ✨
 
 * **Discord Authentication:** Securely log in using your existing Discord account via OAuth 2.0.
+* **Guest Mode:** Start using the app immediately with an anonymous guest account, which can later be linked to Discord.
 * **Room Management:** Easily add, rename, and remove Archipelago rooms you want to track.
+* **Cheese Tracker Integration:** Seamlessly sync your rooms and slots with the Cheese Tracker service.
 * **Player Selection:** Choose exactly which players in a room you want to receive notifications for.
 * **Per-Slot Preferences:** Fine-tune your notifications for *each specific player*, overriding your global defaults.
 * **Real-time Push Notifications:** Get notified for:


### PR DESCRIPTION
This updates the project's markdown documentation to reflect recent code changes without adding unnecessary bloat.

- **readme.md**: Added "Guest Mode" and "Cheese Tracker Integration" to Key Features.
- **backend/SECURITY.md**: Documented new SSRF Protections via custom TCP connector, updated JWT token lifespans (90/730 days), added the guest account pruning policy to data retention, and noted Android Auto Backup exclusion for authentication tokens.
- **LLM.md**: Updated the Authentication section with exact JWT expiration times and guest account pruning policy. Added notes in Gotchas regarding SSRF protection bypasses during local testing, explicit `connector_owner=True` for aiohttp client sessions, and the Android token keystore backup exclusion.

---
*PR created automatically by Jules for task [16472054753568465205](https://jules.google.com/task/16472054753568465205) started by @wrjones104*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Guest Mode and Cheese Tracker Integration to the feature list
  * Updated JWT token expiration timelines (90 days for Discord users, 730 days for guest accounts)
  * Documented automatic removal of inactive guest accounts after 30 days
  * Enhanced security documentation for SSRF protection and authentication handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->