### PR TITLE
feat(cheese): slot notes, statuses, ping preferences & on-demand refresh

### DIFF
--- a/alembic/versions/a1c7e9f4b2d0_add_cheese_default_ping.py
+++ b/alembic/versions/a1c7e9f4b2d0_add_cheese_default_ping.py
@@ -1,0 +1,30 @@
+"""add cheese_default_ping to user
+
+Revision ID: a1c7e9f4b2d0
+Revises: e4a501f78291
+Create Date: 2026-08-03 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1c7e9f4b2d0'
+down_revision: Union[str, Sequence[str], None] = 'e4a501f78291'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('cheese_default_ping', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_column('cheese_default_ping')

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.jones.aptracker"
         minSdk = 26
         targetSdk = 36
-        versionCode = 64
-        versionName = "1.6.21"
+        versionCode = 65
+        versionName = "1.6.22"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["appAuthRedirectScheme"] = "com.jones.aptracker"
         buildConfigField(

--- a/android/app/src/main/java/com/jones/aptracker/network/ApiService.kt
+++ b/android/app/src/main/java/com/jones/aptracker/network/ApiService.kt
@@ -71,6 +71,19 @@ interface ApiService {
     @GET("users/me/tracked-slots")
     suspend fun getUserTrackedSlots(): List<RoomWithTrackedSlots>
 
+    @PUT("rooms/{id}/slots/{slot_id}/cheese")
+    suspend fun updateSlotCheese(
+        @Path("id") roomId: Int,
+        @Path("slot_id") slotId: Int,
+        @Body request: Map<String, @JvmSuppressWildcards Any>
+    ): Response<UpdateCheeseSlotResponse>
+
+    @POST("rooms/{id}/cheese/refresh")
+    suspend fun refreshRoomCheese(@Path("id") roomId: Int): Response<Unit>
+
+    @PUT("users/me/preferences")
+    suspend fun updateCheeseDefaultPing(@Body request: UpdateCheesePingRequest): Response<Unit>
+
     @GET("rooms/{id}/slots/{slot_id}/threshold-groups")
     suspend fun getThresholdGroups(
         @Path("id") roomId: Int,
@@ -332,6 +345,7 @@ data class UserProfile(
     val ui_show_filler_default: Boolean = false,
     val ui_show_trap_default: Boolean = false,
     val is_cheese_connected: Boolean = false,
+    val cheese_default_ping: String? = null,
     val global_snooze_until: String? = null,
     val is_syncing_cheese: Boolean = false
 )
@@ -404,7 +418,34 @@ data class TrackedSlotDetail(
     val notify_finished: Boolean?,
     val use_condensed_messages: Boolean?,
     val snooze_until: String? = null,
-    val suppress_connected: Boolean?
+    val suppress_connected: Boolean?,
+    val cheese: CheeseSlotState? = null
+)
+
+/**
+ * Per-slot Cheese Tracker state. Present only when the user is connected to
+ * Cheese Tracker and the room is linked to a CT tracker. Null otherwise, which
+ * the UI uses to decide whether to show the Cheese Tracker section at all.
+ */
+data class CheeseSlotState(
+    val game_id: Int?,
+    val notes: String = "",
+    val progression_status: String? = null,
+    val completion_status: String? = null,
+    val discord_ping: String? = null,
+    val last_checked: String? = null,
+    val last_activity: String? = null,
+    val is_mine: Boolean = false,
+    val global_ping_policy: String? = null
+)
+
+data class UpdateCheeseSlotResponse(
+    val message: String? = null,
+    val cheese: CheeseSlotState? = null
+)
+
+data class UpdateCheesePingRequest(
+    val cheese_default_ping: String?
 )
 
 data class HintHistoryResponse(

--- a/android/app/src/main/java/com/jones/aptracker/ui/ProfileScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/ProfileScreen.kt
@@ -3,6 +3,7 @@ package com.jones.aptracker.ui
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -31,6 +32,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -262,10 +265,12 @@ fun ProfileScreen(
             CheeseIntegrationCard(
                 isConnected = userProfile?.is_cheese_connected ?: false,
                 isAutoSyncEnabled = isAutoSyncEnabled,
+                defaultPing = userProfile?.cheese_default_ping,
                 onAutoSyncChanged = { userViewModel.setAutoSync(it) },
                 onConnect = { key -> userViewModel.connectCheeseTracker(key) },
                 onSync = { userViewModel.manualSyncCheese() },
-                onDisconnect = { userViewModel.disconnectCheese() }
+                onDisconnect = { userViewModel.disconnectCheese() },
+                onDefaultPingChange = { userViewModel.updateCheeseDefaultPing(it) }
             )
 
             HorizontalDivider(Modifier.padding(vertical = 16.dp))
@@ -428,15 +433,66 @@ fun ProfileMenuItem(
     }
 }
 
+@Composable
+fun CheeseDefaultPingSelector(
+    defaultPing: String?,
+    onDefaultPingChange: (String?) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val currentLabel = CHEESE_PING_OPTIONS.find { it.id == defaultPing }?.label ?: "Not set"
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            "Default ping for new claims",
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Text(
+            "Applied when you claim a new slot. Existing claims are left as-is.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(8.dp))
+        Box {
+            OutlinedButton(
+                onClick = { expanded = true },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(currentLabel, modifier = Modifier.weight(1f))
+                Icon(Icons.Default.KeyboardArrowRight, contentDescription = null)
+            }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                DropdownMenuItem(
+                    text = { Text("Not set") },
+                    onClick = {
+                        expanded = false
+                        onDefaultPingChange(null)
+                    }
+                )
+                CHEESE_PING_OPTIONS.forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(option.label) },
+                        onClick = {
+                            expanded = false
+                            onDefaultPingChange(option.id)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CheeseIntegrationCard(
     isConnected: Boolean,
     isAutoSyncEnabled: Boolean,
+    defaultPing: String?,
     onAutoSyncChanged: (Boolean) -> Unit,
     onConnect: (String) -> Unit,
     onSync: () -> Unit,
-    onDisconnect: () -> Unit
+    onDisconnect: () -> Unit,
+    onDefaultPingChange: (String?) -> Unit
 ) {
     var apiKey by remember { mutableStateOf("") }
     var guestDiscordName by remember { mutableStateOf("") }
@@ -534,6 +590,16 @@ fun CheeseIntegrationCard(
                         modifier = Modifier.padding(start = 16.dp)
                     )
                 }
+
+                Spacer(Modifier.height(8.dp))
+                HorizontalDivider()
+                Spacer(Modifier.height(8.dp))
+
+                // Default ping preference (applied to newly claimed slots only)
+                CheeseDefaultPingSelector(
+                    defaultPing = defaultPing,
+                    onDefaultPingChange = onDefaultPingChange
+                )
 
                 Spacer(Modifier.height(8.dp))
 

--- a/android/app/src/main/java/com/jones/aptracker/ui/SlotDetailScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/SlotDetailScreen.kt
@@ -43,7 +43,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.jones.aptracker.network.ChatMessage
+import com.jones.aptracker.network.CheeseSlotState
 import com.jones.aptracker.network.ConnectionStatus
 import com.jones.aptracker.network.RoomDatapackage
 import com.jones.aptracker.network.TrackedSlotDetail
@@ -123,7 +126,12 @@ fun SlotDetailScreen(
 
     LaunchedEffect(roomDbId, slotId) {
         userViewModel.fetchThresholdGroups(roomDbId, slotId)
+        // Pull the latest tracked-slot data (incl. Cheese state) whenever this
+        // screen opens, so it isn't stale from the last time the Slots list loaded.
+        userViewModel.fetchTrackedSlots()
     }
+
+    val isRefreshingCheese by userViewModel.isRefreshingCheese.collectAsState()
 
     val thresholdGroups by userViewModel.thresholdGroups.collectAsState()
 
@@ -162,10 +170,19 @@ fun SlotDetailScreen(
             },
             containerColor = MaterialTheme.colorScheme.background
         ) { padding ->
+            SwipeRefresh(
+                state = rememberSwipeRefreshState(isRefreshing = isRefreshingCheese),
+                onRefresh = {
+                    // If this slot is synced with Cheese Tracker, pull its live state;
+                    // otherwise just reload tracked-slot data.
+                    if (slot.cheese != null) userViewModel.refreshCheeseFromServer(roomDbId)
+                    else userViewModel.fetchTrackedSlots()
+                },
+                modifier = Modifier.padding(padding)
+            ) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(padding)
                     .imePadding()
                     .verticalScroll(rememberScrollState())
                     .padding(16.dp)
@@ -222,6 +239,24 @@ fun SlotDetailScreen(
                         title = "Notification Settings",
                         subtitle = "Customize how you are notified for this slot",
                         onClick = { showSettingsSheet = true }
+                    )
+                }
+
+                // 2b. CHEESE TRACKER SECTION (only when synced with Cheese Tracker)
+                val cheeseState = slot.cheese
+                if (cheeseState != null) {
+                    val isSavingCheese by userViewModel.isSavingCheeseSlot.collectAsState()
+                    Spacer(Modifier.height(24.dp))
+                    CheeseSlotCard(
+                        cheese = cheeseState,
+                        isSaving = isSavingCheese,
+                        isRefreshing = isRefreshingCheese,
+                        onRefresh = { userViewModel.refreshCheeseFromServer(roomDbId) },
+                        onProgressionChange = { userViewModel.updateCheeseProgression(roomDbId, slotId, it) },
+                        onCompletionChange = { userViewModel.updateCheeseCompletion(roomDbId, slotId, it) },
+                        onPingChange = { userViewModel.updateCheesePing(roomDbId, slotId, it) },
+                        onStillBk = { userViewModel.stillBk(roomDbId, slotId) },
+                        onSaveNotes = { userViewModel.updateCheeseNotes(roomDbId, slotId, it) }
                     )
                 }
 
@@ -480,6 +515,7 @@ fun SlotDetailScreen(
                 }
                 Spacer(Modifier.height(40.dp))
             }
+            }
         }
     }
 
@@ -633,6 +669,319 @@ fun ActionCard(icon: ImageVector, title: String, subtitle: String, onClick: () -
                 Text(subtitle, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
             }
             Icon(Icons.Default.ChevronRight, null, tint = Color.Gray)
+        }
+    }
+}
+
+// --- Cheese Tracker slot editing ---
+
+data class CheeseStatusOption(val id: String, val label: String, val color: Color)
+
+val CHEESE_PROGRESSION_OPTIONS = listOf(
+    CheeseStatusOption("unknown", "Unknown", Color.Gray),
+    CheeseStatusOption("unblocked", "Unblocked", Color(0xFF90CAF9)),
+    CheeseStatusOption("bk", "BK", Color(0xFFCF6679)),
+    CheeseStatusOption("soft_bk", "Soft BK", Color(0xFFFFB74D)),
+    CheeseStatusOption("go", "Go Mode", Color(0xFF4CAF50))
+)
+
+val CHEESE_COMPLETION_OPTIONS = listOf(
+    CheeseStatusOption("incomplete", "Incomplete", Color.Gray),
+    CheeseStatusOption("all_checks", "All Checks", Color(0xFF4FC3F7)),
+    CheeseStatusOption("goal", "Goal", Color(0xFF4FC3F7)),
+    CheeseStatusOption("done", "Done", Color(0xFF4CAF50)),
+    CheeseStatusOption("released", "Forfeit", Color.Gray)
+)
+
+val CHEESE_PING_OPTIONS = listOf(
+    CheeseStatusOption("liberally", "Liberally", Color(0xFF4CAF50)),
+    CheeseStatusOption("sparingly", "Sparingly", Color(0xFFFFB74D)),
+    CheeseStatusOption("hints", "Hints", Color(0xFFFFB74D)),
+    CheeseStatusOption("see_notes", "See Notes", Color(0xFF4FC3F7)),
+    CheeseStatusOption("never", "Never", Color(0xFFCF6679))
+)
+
+private fun cheeseOptionLabel(options: List<CheeseStatusOption>, id: String?): String =
+    options.find { it.id == id }?.label ?: (id ?: "—")
+
+private val CHEESE_BK_IDS = setOf("bk", "soft_bk")
+private val CHEESE_COMPLETE_IDS = setOf("done", "released")
+
+@Composable
+fun CheeseSlotCard(
+    cheese: CheeseSlotState,
+    isSaving: Boolean,
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit,
+    onProgressionChange: (String) -> Unit,
+    onCompletionChange: (String) -> Unit,
+    onPingChange: (String) -> Unit,
+    onStillBk: () -> Unit,
+    onSaveNotes: (String) -> Unit
+) {
+    val canEdit = cheese.is_mine
+    var showForfeitConfirm by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            // Card header: title + refresh-this-card control
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Cheese Tracker",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                IconButton(onClick = onRefresh, enabled = !isRefreshing && !isSaving) {
+                    if (isRefreshing) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                    } else {
+                        Icon(
+                            Icons.Default.Refresh,
+                            contentDescription = "Refresh from Cheese Tracker",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+
+            if (!canEdit) {
+                Text(
+                    "This slot is claimed by someone else on Cheese Tracker, so it's view-only here.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray
+                )
+                Spacer(Modifier.height(16.dp))
+            }
+
+            // --- Status selectors ---
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                CheeseDropdownField(
+                    modifier = Modifier.weight(1f),
+                    label = "STATUS",
+                    selectedId = cheese.progression_status,
+                    options = CHEESE_PROGRESSION_OPTIONS,
+                    enabled = canEdit && !isSaving,
+                    onSelect = { onProgressionChange(it) }
+                )
+                CheeseDropdownField(
+                    modifier = Modifier.weight(1f),
+                    label = "COMPLETION",
+                    selectedId = cheese.completion_status,
+                    options = CHEESE_COMPLETION_OPTIONS,
+                    enabled = canEdit && !isSaving,
+                    onSelect = { selected ->
+                        if (selected == "released") showForfeitConfirm = true
+                        else onCompletionChange(selected)
+                    }
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // --- Last checked + Still BK ---
+            val isBk = cheese.progression_status in CHEESE_BK_IDS
+            val isCompleted = cheese.completion_status in CHEESE_COMPLETE_IDS
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("LAST CHECKED", style = MaterialTheme.typography.labelSmall, color = Color.Gray, fontWeight = FontWeight.Bold)
+                    Text(
+                        formatTimestamp(cheese.last_checked ?: cheese.last_activity),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+                if (canEdit && isBk && !isCompleted) {
+                    OutlinedButton(
+                        onClick = onStillBk,
+                        enabled = !isSaving,
+                        shape = RoundedCornerShape(24.dp)
+                    ) {
+                        Text("Still BK")
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // --- Ping preference ---
+            if (cheese.global_ping_policy != null) {
+                Text("PING PREFERENCE", style = MaterialTheme.typography.labelSmall, color = Color.Gray, fontWeight = FontWeight.Bold)
+                Text(
+                    cheeseOptionLabel(CHEESE_PING_OPTIONS, cheese.discord_ping),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    "This tracker uses a global ping policy, so per-slot ping is set by the tracker owner.",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.Gray,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            } else {
+                CheeseDropdownField(
+                    modifier = Modifier.fillMaxWidth(),
+                    label = "PING PREFERENCE",
+                    selectedId = cheese.discord_ping,
+                    options = CHEESE_PING_OPTIONS,
+                    enabled = canEdit && !isSaving,
+                    onSelect = { onPingChange(it) }
+                )
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // --- Notes ---
+            Text("NOTES", style = MaterialTheme.typography.labelSmall, color = Color.Gray, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(8.dp))
+            var notesDraft by remember(cheese.notes) { mutableStateOf(cheese.notes) }
+            val notesChanged = notesDraft != cheese.notes
+            OutlinedTextField(
+                value = notesDraft,
+                onValueChange = { if (it.length <= 5000) notesDraft = it },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = canEdit && !isSaving,
+                placeholder = { Text("Add notes for this slot...") },
+                minLines = 3,
+                shape = RoundedCornerShape(12.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            )
+            if (canEdit && notesChanged) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    TextButton(onClick = { notesDraft = cheese.notes }, enabled = !isSaving) {
+                        Text("Cancel")
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = { onSaveNotes(notesDraft) }, enabled = !isSaving) {
+                        Text("Save Notes")
+                    }
+                }
+            }
+        }
+    }
+
+    if (showForfeitConfirm) {
+        AlertDialog(
+            onDismissRequest = { showForfeitConfirm = false },
+            title = { Text("Mark as Forfeit?") },
+            text = {
+                Text(
+                    "Forfeit is permanent on Cheese Tracker — once set, it cannot be changed back through the app or the website. Continue?"
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showForfeitConfirm = false
+                        onCompletionChange("released")
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) {
+                    Text("Forfeit")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showForfeitConfirm = false }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CheeseDropdownField(
+    modifier: Modifier = Modifier,
+    label: String,
+    selectedId: String?,
+    options: List<CheeseStatusOption>,
+    enabled: Boolean,
+    onSelect: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selected = options.find { it.id == selectedId }
+
+    Column(modifier = modifier) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = Color.Gray, fontWeight = FontWeight.Bold)
+        Spacer(Modifier.height(4.dp))
+        Box {
+            Surface(
+                onClick = { if (enabled) expanded = true },
+                enabled = enabled,
+                shape = RoundedCornerShape(12.dp),
+                color = MaterialTheme.colorScheme.surface,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(10.dp)
+                            .clip(CircleShape)
+                            .background(selected?.color ?: Color.Gray)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        selected?.label ?: (selectedId ?: "—"),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Icon(
+                        Icons.Default.KeyboardArrowDown,
+                        null,
+                        tint = Color.Gray,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                options.forEach { option ->
+                    DropdownMenuItem(
+                        text = {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(10.dp)
+                                        .clip(CircleShape)
+                                        .background(option.color)
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Text(option.label)
+                            }
+                        },
+                        onClick = {
+                            expanded = false
+                            if (option.id != selectedId) onSelect(option.id)
+                        }
+                    )
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/jones/aptracker/ui/UserViewModel.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/UserViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.jones.aptracker.data.SettingsManager
 import com.jones.aptracker.network.CheeseAuthRequest
+import com.jones.aptracker.network.CheeseSlotState
+import com.jones.aptracker.network.UpdateCheesePingRequest
 import com.jones.aptracker.network.IgnoreItem
 import com.jones.aptracker.network.WhitelistItem
 import com.jones.aptracker.network.RetrofitClient
@@ -198,14 +200,17 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun fetchTrackedSlots() {
-        viewModelScope.launch {
-            try {
-                _trackedSlotsByRoom.value = RetrofitClient.instance.getUserTrackedSlots()
-            } catch (e: Exception) {
-                _errorMessage.value = "Failed to load tracked slots."
-                e.printStackTrace()
-                _trackedSlotsByRoom.value = emptyList()
-            }
+        viewModelScope.launch { loadTrackedSlots() }
+    }
+
+    /** Awaitable tracked-slots load, so callers (e.g. refresh) can sequence work. */
+    private suspend fun loadTrackedSlots() {
+        try {
+            _trackedSlotsByRoom.value = RetrofitClient.instance.getUserTrackedSlots()
+        } catch (e: Exception) {
+            _errorMessage.value = "Failed to load tracked slots."
+            e.printStackTrace()
+            _trackedSlotsByRoom.value = emptyList()
         }
     }
 
@@ -401,6 +406,161 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
 
     fun clearIntegrationMessage() {
         _integrationMessage.value = null
+    }
+
+    // --- Cheese slot state (notes / status / ping) editing ---
+
+    /** True while a Cheese slot write is in flight, to disable controls. */
+    private val _isSavingCheeseSlot = MutableStateFlow(false)
+    val isSavingCheeseSlot: StateFlow<Boolean> = _isSavingCheeseSlot.asStateFlow()
+
+    /** True while an on-demand Cheese Tracker refresh is in flight. */
+    private val _isRefreshingCheese = MutableStateFlow(false)
+    val isRefreshingCheese: StateFlow<Boolean> = _isRefreshingCheese.asStateFlow()
+
+    /**
+     * Applies an optimistic change to a slot's Cheese state, sends the partial
+     * update to the backend, then reconciles the local state against the
+     * server's authoritative response (Cheese may force-upgrade completion).
+     * Rolls back and surfaces an error on failure.
+     */
+    private fun submitCheeseSlotUpdate(
+        roomId: Int,
+        slotId: Int,
+        updates: Map<String, Any>,
+        optimistic: (CheeseSlotState) -> CheeseSlotState
+    ) {
+        viewModelScope.launch {
+            val previousRooms = _trackedSlotsByRoom.value
+            val currentRoom = previousRooms.find { it.room_db_id == roomId }
+            val currentSlot = currentRoom?.tracked_slots?.find { it.slot_id == slotId }
+            val currentCheese = currentSlot?.cheese ?: return@launch
+
+            // 1. Optimistic local update.
+            _trackedSlotsByRoom.value = replaceSlotCheese(previousRooms, roomId, slotId, optimistic(currentCheese))
+            _isSavingCheeseSlot.value = true
+
+            try {
+                val response = RetrofitClient.instance.updateSlotCheese(roomId, slotId, updates)
+                val body = response.body()
+                if (response.isSuccessful && body?.cheese != null) {
+                    // 2. Reconcile with the authoritative server state.
+                    _trackedSlotsByRoom.value = replaceSlotCheese(
+                        _trackedSlotsByRoom.value, roomId, slotId, body.cheese
+                    )
+                } else {
+                    _trackedSlotsByRoom.value = previousRooms
+                    _errorMessage.value = when (response.code()) {
+                        403 -> "This slot is claimed by someone else on Cheese Tracker."
+                        409 -> "This slot changed on Cheese Tracker. Pull to refresh and try again."
+                        429 -> "Too many updates. Please slow down."
+                        502 -> "Could not reach Cheese Tracker. Please try again."
+                        else -> "Failed to update Cheese Tracker."
+                    }
+                }
+            } catch (e: Exception) {
+                _trackedSlotsByRoom.value = previousRooms
+                _errorMessage.value = "Failed to update Cheese Tracker."
+                e.printStackTrace()
+            } finally {
+                _isSavingCheeseSlot.value = false
+            }
+        }
+    }
+
+    private fun replaceSlotCheese(
+        rooms: List<RoomWithTrackedSlots>,
+        roomId: Int,
+        slotId: Int,
+        newCheese: CheeseSlotState
+    ): List<RoomWithTrackedSlots> {
+        return rooms.map { room ->
+            if (room.room_db_id == roomId) {
+                room.copy(
+                    tracked_slots = room.tracked_slots.map { slot ->
+                        if (slot.slot_id == slotId) slot.copy(cheese = newCheese) else slot
+                    }
+                )
+            } else {
+                room
+            }
+        }
+    }
+
+    fun updateCheeseNotes(roomId: Int, slotId: Int, notes: String) {
+        submitCheeseSlotUpdate(roomId, slotId, mapOf("notes" to notes)) { it.copy(notes = notes) }
+    }
+
+    fun updateCheeseProgression(roomId: Int, slotId: Int, status: String) {
+        submitCheeseSlotUpdate(
+            roomId, slotId, mapOf("progression_status" to status)
+        ) { it.copy(progression_status = status) }
+    }
+
+    fun updateCheeseCompletion(roomId: Int, slotId: Int, status: String) {
+        submitCheeseSlotUpdate(
+            roomId, slotId, mapOf("completion_status" to status)
+        ) { it.copy(completion_status = status) }
+    }
+
+    fun updateCheesePing(roomId: Int, slotId: Int, ping: String) {
+        submitCheeseSlotUpdate(
+            roomId, slotId, mapOf("discord_ping" to ping)
+        ) { it.copy(discord_ping = ping) }
+    }
+
+    /** "Still BK": refresh last_checked without changing status. */
+    fun stillBk(roomId: Int, slotId: Int) {
+        submitCheeseSlotUpdate(roomId, slotId, mapOf("touch_last_checked" to true)) { it }
+    }
+
+    /**
+     * Forces the backend to pull this room's current state from Cheese Tracker
+     * (bypassing the ~5 min poll), then reloads tracked slots so the UI shows it.
+     */
+    fun refreshCheeseFromServer(roomId: Int, onComplete: () -> Unit = {}) {
+        viewModelScope.launch {
+            _isRefreshingCheese.value = true
+            try {
+                val response = RetrofitClient.instance.refreshRoomCheese(roomId)
+                if (response.isSuccessful) {
+                    loadTrackedSlots()
+                } else {
+                    _errorMessage.value = when (response.code()) {
+                        429 -> "Refreshing too fast. Please wait a moment."
+                        502 -> "Could not reach Cheese Tracker. Please try again."
+                        else -> "Failed to refresh from Cheese Tracker."
+                    }
+                }
+            } catch (e: Exception) {
+                _errorMessage.value = "Failed to refresh from Cheese Tracker."
+                e.printStackTrace()
+            } finally {
+                _isRefreshingCheese.value = false
+                onComplete()
+            }
+        }
+    }
+
+    /** Sets (or clears, when null) the user's default Cheese ping preference. */
+    fun updateCheeseDefaultPing(ping: String?) {
+        viewModelScope.launch {
+            val previousProfile = _userProfile.value
+            _userProfile.value = previousProfile?.copy(cheese_default_ping = ping)
+            try {
+                val response = RetrofitClient.instance.updateCheeseDefaultPing(
+                    UpdateCheesePingRequest(ping)
+                )
+                if (!response.isSuccessful) {
+                    _userProfile.value = previousProfile
+                    _errorMessage.value = "Failed to save default ping."
+                }
+            } catch (e: Exception) {
+                _userProfile.value = previousProfile
+                _errorMessage.value = "Failed to save default ping."
+                e.printStackTrace()
+            }
+        }
     }
 
     // ============================================================================================

--- a/android/app/src/main/java/com/jones/aptracker/ui/WhatsNewBottomSheet.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/WhatsNewBottomSheet.kt
@@ -66,9 +66,9 @@ fun WhatsNewBottomSheet(
 
 
             val highlights = releaseInfo?.highlights ?: listOf(
-                "Real-Time History Sync Progress: Track history sync status live with a dynamic percentage bar (X% / 100%) and clear progress indicators.",
-                "Background History Syncing: History syncing now continues seamlessly via WorkManager and ApplicationScope when screen is locked or app is minimized.",
-                "Instant Ignore & Whitelist Updates: Mute rules and whitelists update instantly when returning to the history screen without needing an app restart."
+                "Cheese Tracker Notes & Status: View and edit your Cheese Tracker notes and status (Unknown, Unblocked, BK, Soft BK, Go Mode) right from a slot's detail screen.",
+                "\"Still BK\" Button: Keep your BK/Soft BK status while refreshing your Last Checked time, matching the Cheese Tracker web feature.",
+                "Ping Preferences: Set per-slot ping preferences, plus a default ping applied to newly claimed slots from the Profile screen."
             )
 
             // Highlights

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the **Archipelago Alerts Backend Server & API** will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.22] - 2026-08-03
+
+> **Discord Copy-Paste Format:**
+> ```markdown
+> **Archipelago Alerts Backend v1.6.22 Released!**
+> 
+> **New: Cheese Tracker Notes & Statuses**
+> • **Per-Slot State API**: `GET /api/user/tracked_slots` now includes a `cheese` object per slot (notes, progression/completion status, ping, last checked, ownership).
+> • **Slot Editing**: New `PUT /rooms/<room_db_id>/slots/<slot_id>/cheese` to edit notes/status/ping and refresh "Last Checked" ("Still BK"), with ownership checks and optimistic-conflict handling.
+> • **Default Ping Preference**: `cheese_default_ping` is now applied at claim time, fixing the ping preference always defaulting to "Never".
+> ```
+
+### Added
+- **Cheese Slot State (read)**: `get_user_tracked_slots` in `slots_routes.py` parses the room's cached Cheese Tracker data and attaches a per-slot `cheese` object (`game_id`, `notes`, `progression_status`, `completion_status`, `discord_ping`, `last_checked`, `is_mine`, `global_ping_policy`) for Cheese-connected users.
+- **Cheese Slot State (write)**: New synchronous `PUT /rooms/<room_db_id>/slots/<slot_id>/cheese` endpoint. Validates enum values, re-fetches the tracker, enforces ownership, applies partial updates, stamps `last_checked` for BK/Soft BK and "Still BK", sends `x-if-owner-is` as a conflict guard, and splices the authoritative response back into the room cache.
+- **`User.cheese_default_ping`**: New nullable column (Alembic `a1c7e9f4b2d0`) exposed on the user profile and settable via `PUT /users/me/preferences`.
+
+### Changed
+- **Claim-Time Ping Default**: `send_state` in `api_cheese.py` now applies the user's `cheese_default_ping` when claiming a slot, and aligns unclaim behavior with Cheese Tracker's web UI (availability → `open`, ping → `never`).
+
+### Fixed
+- **Ping Preference Stuck on "Never"**: Newly claimed slots now honor the user's chosen default ping preference instead of always defaulting to "Never".
+
+---
+
 ## [1.6.21] - 2026-08-03
 
 > **Discord Copy-Paste Format:**

--- a/backend/app/api_cheese.py
+++ b/backend/app/api_cheese.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 from flask import Blueprint, request, jsonify, current_app
 from sqlalchemy.exc import IntegrityError
 from dotenv import load_dotenv
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from . import Session
 from .models import User, TrackedRoom, UserRoomSubscription, UserTrackedSlot
@@ -811,10 +811,19 @@ def send_state(session, app, ap_position, is_tracked, current_user_id_for_thread
             payload['claimed_by_ct_user_id'] = my_ct_id
             payload['discord_username'] = None if my_ct_id is not None else my_discord
             payload['availability_status'] = "claimed"
+            # Apply the user's default ping preference at claim time (mirrors CT's
+            # web UI, which seeds discord_ping from the user's default on claim).
+            # Null default leaves whatever the slot already had.
+            default_ping = getattr(user, 'cheese_default_ping', None)
+            if default_ping:
+                payload['discord_ping'] = default_ping
         else:
             payload['claimed_by_ct_user_id'] = None
             payload['discord_username'] = None
-            payload['availability_status'] = "unknown"
+            # Align with CT's web UI on unclaim: availability returns to "open"
+            # and the ping preference resets to "never".
+            payload['availability_status'] = "open"
+            payload['discord_ping'] = "never"
         
         # 5. Prepare final headers
         put_headers = base_headers.copy()
@@ -844,6 +853,249 @@ def send_state(session, app, ap_position, is_tracked, current_user_id_for_thread
 
     except Exception as e:
         logging.error(f"[CHEESE_DEBUG] Error pushing pos {ap_position}: {e}", exc_info=True)
+
+# Progression statuses that, when set, should also stamp last_checked (mirrors
+# CT's web UI: setting BK/Soft BK updates "last checked").
+_CHEESE_BK_STATUSES = {'bk', 'soft_bk'}
+
+
+def apply_cheese_slot_update(app, user_id, room_db_id, slot_id, updates):
+    """
+    Synchronously applies a partial update to a single game (slot) on Cheese
+    Tracker and splices the result back into the local cache.
+
+    `updates` is a dict that may contain any of:
+        notes (str), progression_status (str), completion_status (str),
+        discord_ping (str), touch_last_checked (bool)
+
+    Returns a result dict:
+        {'status': 'ok', 'game': <updated game dict>, 'global_ping_policy': ...}
+        {'status': 'not_connected' | 'no_tracker' | 'not_tracked' |
+                   'not_found' | 'forbidden' | 'conflict' | 'error'}
+    """
+    # === 1. PRE-FLIGHT (DB) ===
+    api_key = None
+    tracker_id = None
+    my_ct_id = None
+    my_discord_clean = None
+    with app.app_context():
+        session = Session()
+        try:
+            user = session.query(User).filter_by(id=user_id).first()
+            if not user or not user.cheese_api_key:
+                return {'status': 'not_connected'}
+
+            room = session.query(TrackedRoom).filter_by(id=room_db_id).first()
+            if not room or not room.cheese_tracker_id:
+                return {'status': 'no_tracker'}
+
+            local_slot = session.query(UserTrackedSlot).filter_by(
+                user_id=user_id, room_id=room_db_id, slot_id=slot_id
+            ).first()
+            if not local_slot:
+                return {'status': 'not_tracked'}
+
+            api_key = decrypt_api_key(user.cheese_api_key)
+            if not api_key:
+                logging.error(f"[CHEESE_SLOT] Failed to decrypt key for user {user_id}.")
+                return {'status': 'error'}
+
+            tracker_id = room.cheese_tracker_id
+            my_ct_id = user.cheese_user_id
+            my_discord_clean = user.discord_username.strip().lower() if user.discord_username else None
+        finally:
+            Session.remove()
+
+    # === 2. NETWORK PHASE (no DB session held) ===
+    base_headers = get_cheese_headers()
+    base_headers["Authorization"] = f"Bearer {api_key}"
+
+    try:
+        detail_resp = requests.get(f"{CHEESE_BASE_URL}/tracker/{tracker_id}", headers=base_headers, timeout=10)
+        if not detail_resp.ok:
+            logging.warning(f"[CHEESE_SLOT] Failed to fetch tracker {tracker_id}: {detail_resp.status_code}")
+            return {'status': 'error'}
+
+        details = detail_resp.json()
+        games = details.get('games', [])
+
+        game_object = None
+        for game in games:
+            if game.get('position') == slot_id:
+                game_object = game
+                break
+
+        if not game_object:
+            return {'status': 'not_found'}
+
+        # Ownership check (mirrors send_state): the current user must own the slot.
+        remote_owner_id = game_object.get('claimed_by_ct_user_id')
+        if remote_owner_id is not None:
+            is_mine = (my_ct_id is not None and remote_owner_id == my_ct_id)
+        else:
+            claim_discord = game_object.get('effective_discord_username') or game_object.get('discord_username')
+            claim_discord_clean = claim_discord.strip().lower() if claim_discord else None
+            is_mine = (claim_discord_clean is not None and my_discord_clean is not None
+                       and claim_discord_clean == my_discord_clean)
+
+        if not is_mine:
+            logging.warning(f"[CHEESE_SLOT] User {user_id} attempted to edit unowned slot {slot_id} in {tracker_id}.")
+            return {'status': 'forbidden'}
+
+        cheese_game_id = game_object.get('id')
+        if not cheese_game_id:
+            logging.error(f"[CHEESE_SLOT] Game object for pos {slot_id} has no id.")
+            return {'status': 'error'}
+
+        # Build the PUT payload from the current object, applying only the deltas.
+        payload = game_object.copy()
+        now_iso = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+        if 'notes' in updates:
+            payload['notes'] = updates['notes'] or ''
+        if 'discord_ping' in updates:
+            payload['discord_ping'] = updates['discord_ping']
+        if 'completion_status' in updates:
+            payload['completion_status'] = updates['completion_status']
+        if 'progression_status' in updates:
+            payload['progression_status'] = updates['progression_status']
+            # Setting a BK status also refreshes last_checked, matching CT's UI.
+            if updates['progression_status'] in _CHEESE_BK_STATUSES:
+                payload['last_checked'] = now_iso
+        # "Still BK": explicit request to refresh last_checked without other changes.
+        if updates.get('touch_last_checked'):
+            payload['last_checked'] = now_iso
+
+        # x-if-owner-is guard: fail (412) if the claim changed under us.
+        put_headers = base_headers.copy()
+        put_headers['x-if-owner-is'] = json.dumps({
+            "claimed_by_ct_user_id": game_object.get('claimed_by_ct_user_id'),
+            "discord_username": game_object.get('discord_username')
+        })
+
+        url = f"{CHEESE_BASE_URL}/tracker/{tracker_id}/game/{cheese_game_id}"
+        put_resp = requests.put(url, json=payload, headers=put_headers, timeout=10)
+
+        if put_resp.status_code == 412:
+            return {'status': 'conflict'}
+        if put_resp.status_code not in (200, 204):
+            logging.warning(f"[CHEESE_SLOT] PUT failed for game {cheese_game_id}: {put_resp.status_code} {put_resp.text}")
+            return {'status': 'error'}
+
+        # The response body is the authoritative updated game (CT may force-upgrade
+        # completion_status). Fall back to our payload if the body is empty (204).
+        updated_game = payload
+        try:
+            if put_resp.content:
+                body = put_resp.json()
+                if isinstance(body, dict):
+                    updated_game = body
+        except Exception:
+            updated_game = payload
+
+    except requests.exceptions.RequestException as e:
+        logging.error(f"[CHEESE_SLOT] Network error updating slot {slot_id}: {e}")
+        return {'status': 'error'}
+    except Exception as e:
+        logging.error(f"[CHEESE_SLOT] Unexpected error updating slot {slot_id}: {e}", exc_info=True)
+        return {'status': 'error'}
+
+    # === 3. DB PHASE: splice updated game into cached_cheese_json ===
+    with app.app_context():
+        session = Session()
+        try:
+            room = session.query(TrackedRoom).filter_by(id=room_db_id).first()
+            if room and room.cached_cheese_json:
+                try:
+                    cached = json.loads(room.cached_cheese_json)
+                    if isinstance(cached, dict) and isinstance(cached.get('games'), list):
+                        for idx, g in enumerate(cached['games']):
+                            if g.get('position') == slot_id:
+                                # Preserve computed fields from the cache that the
+                                # game PUT response may not include.
+                                merged = g.copy()
+                                merged.update(updated_game)
+                                cached['games'][idx] = merged
+                                updated_game = merged
+                                break
+                        room.cached_cheese_json = json.dumps(cached)
+                        session.commit()
+                except (json.JSONDecodeError, TypeError) as e:
+                    logging.warning(f"[CHEESE_SLOT] Could not splice cache for room {room_db_id}: {e}")
+                    session.rollback()
+        except Exception as e:
+            session.rollback()
+            logging.error(f"[CHEESE_SLOT] DB splice failed: {e}", exc_info=True)
+        finally:
+            Session.remove()
+
+    return {
+        'status': 'ok',
+        'game': updated_game,
+        'global_ping_policy': details.get('global_ping_policy')
+    }
+
+
+def refresh_tracker_cache(app, user_id, room_db_id):
+    """
+    On-demand refresh of a single room's Cheese Tracker cache. Performs an
+    authenticated GET of the tracker and runs the same processing the background
+    poller uses, so the local cache reflects Cheese Tracker's current state
+    immediately instead of waiting for the next ~5 minute poll cycle.
+
+    Returns {'status': 'ok'} or {'status': 'not_connected'|'no_tracker'|'error'}.
+    """
+    api_key = None
+    tracker_id = None
+    with app.app_context():
+        session = Session()
+        try:
+            user = session.query(User).filter_by(id=user_id).first()
+            if not user or not user.cheese_api_key:
+                return {'status': 'not_connected'}
+            room = session.query(TrackedRoom).filter_by(id=room_db_id).first()
+            if not room or not room.cheese_tracker_id:
+                return {'status': 'no_tracker'}
+            api_key = decrypt_api_key(user.cheese_api_key)
+            if not api_key:
+                logging.error(f"[CHEESE_REFRESH] Failed to decrypt key for user {user_id}.")
+                return {'status': 'error'}
+            tracker_id = room.cheese_tracker_id
+        finally:
+            Session.remove()
+
+    headers = get_cheese_headers()
+    headers['Authorization'] = f"Bearer {api_key}"
+    try:
+        resp = requests.get(f"{CHEESE_BASE_URL}/tracker/{tracker_id}", headers=headers, timeout=10)
+        if not resp.ok:
+            logging.warning(f"[CHEESE_REFRESH] Fetch failed for {tracker_id}: {resp.status_code}")
+            return {'status': 'error'}
+        data = resp.json()
+    except requests.exceptions.RequestException as e:
+        logging.error(f"[CHEESE_REFRESH] Network error for {tracker_id}: {e}")
+        return {'status': 'error'}
+    except Exception as e:
+        logging.error(f"[CHEESE_REFRESH] Unexpected error for {tracker_id}: {e}", exc_info=True)
+        return {'status': 'error'}
+
+    remote_updated_at = data.get('updated_at')
+    if not remote_updated_at:
+        logging.warning(f"[CHEESE_REFRESH] Tracker {tracker_id} returned no updated_at.")
+        return {'status': 'error'}
+
+    try:
+        # Reuse the poller's processing so a manual refresh behaves identically
+        # to a poll cycle (cache update + claim reconciliation).
+        from app.poller import process_cheese_update
+        with app.app_context():
+            process_cheese_update(room_db_id, data, remote_updated_at)
+    except Exception as e:
+        logging.error(f"[CHEESE_REFRESH] Processing failed for room {room_db_id}: {e}", exc_info=True)
+        return {'status': 'error'}
+
+    return {'status': 'ok'}
+
 
 def update_tracker_visibility(app, user_id, cheese_tracker_id, visibility):
     """

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -23,6 +23,10 @@ class User(Base):
     cheese_last_sync = Column(DateTime, nullable=True)
     is_syncing_cheese = Column(Boolean, nullable=False, default=False, server_default='f')
     cheese_sync_started_at = Column(DateTime, nullable=True)
+    # Default Cheese Tracker ping preference applied at claim time. Null = leave
+    # whatever value the game already has on Cheese untouched. One of:
+    # liberally | sparingly | hints | see_notes | never
+    cheese_default_ping = Column(String, nullable=True)
     is_guest = Column(Boolean, nullable=False, default=True, server_default='t')
     guest_uuid = Column(String, nullable=True, unique=True, index=True)
     subscriptions = relationship("UserRoomSubscription", back_populates="user", cascade="all, delete-orphan")

--- a/backend/app/routes/slots_routes.py
+++ b/backend/app/routes/slots_routes.py
@@ -15,6 +15,47 @@ from app.routes.common import log_api_call, token_required, handle_db_errors, fo
 
 slots_bp = Blueprint('slots_routes', __name__)
 
+# Valid Cheese Tracker enum wire values (from CT's db/model.rs). Used to build
+# and validate the per-slot Cheese state.
+VALID_CHEESE_PROGRESSION = {'unknown', 'unblocked', 'bk', 'soft_bk', 'go'}
+VALID_CHEESE_COMPLETION = {'incomplete', 'all_checks', 'goal', 'done', 'released'}
+VALID_CHEESE_PING = {'liberally', 'sparingly', 'hints', 'see_notes', 'never'}
+# Progression statuses that represent "beatable but blocked" and, per CT's web
+# UI, stamp last_checked when set (enabling the "Still BK" behavior).
+CHEESE_BK_STATUSES = {'bk', 'soft_bk'}
+
+
+def game_is_owned_by(game, cheese_user_id, discord_username_clean):
+    """
+    Determines whether a Cheese game object is claimed by the given user.
+    Mirrors the ownership logic in api_cheese.send_state: prefer the
+    authenticated ct_user_id, fall back to an unauthenticated discord-name match.
+    """
+    remote_owner_id = game.get('claimed_by_ct_user_id')
+    if remote_owner_id is not None:
+        return cheese_user_id is not None and remote_owner_id == cheese_user_id
+
+    claim_discord = game.get('effective_discord_username') or game.get('discord_username')
+    claim_discord_clean = claim_discord.strip().lower() if claim_discord else None
+    if claim_discord_clean is None:
+        return False
+    return discord_username_clean is not None and claim_discord_clean == discord_username_clean
+
+
+def build_cheese_slot_state(game, global_ping_policy, cheese_user_id, discord_username_clean):
+    """Builds the per-slot Cheese sub-object attached to a tracked slot."""
+    return {
+        'game_id': game.get('id'),
+        'notes': game.get('notes') or '',
+        'progression_status': game.get('progression_status'),
+        'completion_status': game.get('completion_status'),
+        'discord_ping': game.get('discord_ping'),
+        'last_checked': game.get('last_checked'),
+        'last_activity': game.get('last_activity'),
+        'is_mine': game_is_owned_by(game, cheese_user_id, discord_username_clean),
+        'global_ping_policy': global_ping_policy,
+    }
+
 @slots_bp.route('/rooms/<int:room_db_id>/slots', methods=['PUT'])
 @handle_db_errors
 @log_api_call
@@ -129,6 +170,140 @@ def update_slot_preferences(current_user, room_db_id, slot_id):
     finally:
         Session.remove()
 
+# Simple in-process per-user throttle for Cheese slot writes. Each write costs a
+# GET + PUT against Cheese Tracker, so we cap how often a user can fire them.
+_cheese_write_last = {}
+_CHEESE_WRITE_MIN_INTERVAL = timedelta(seconds=2)
+
+# Separate throttle for on-demand tracker refreshes (one CT GET each).
+_cheese_refresh_last = {}
+_CHEESE_REFRESH_MIN_INTERVAL = timedelta(seconds=3)
+
+
+@slots_bp.route('/rooms/<int:room_db_id>/cheese/refresh', methods=['POST'])
+@handle_db_errors
+@log_api_call
+@token_required
+def refresh_room_cheese(current_user, room_db_id):
+    """
+    On-demand refresh of a room's Cheese Tracker cache, bypassing the ~5 minute
+    background poll so a user can pull the current state immediately.
+    """
+    if not current_user.cheese_api_key:
+        return jsonify({'error': 'Not connected to Cheese Tracker.'}), 400
+
+    session = Session()
+    sub = session.query(UserRoomSubscription).filter_by(
+        user_id=current_user.id, room_id=room_db_id
+    ).first()
+    if not sub:
+        return jsonify({'error': 'You are not subscribed to this room.'}), 403
+
+    now = datetime.utcnow()
+    last = _cheese_refresh_last.get(current_user.id)
+    if last is not None and (now - last) < _CHEESE_REFRESH_MIN_INTERVAL:
+        return jsonify({'error': 'Refreshing too fast. Please wait a moment.'}), 429
+    _cheese_refresh_last[current_user.id] = now
+
+    from app.api_cheese import refresh_tracker_cache
+    app_context = current_app._get_current_object()
+    result = refresh_tracker_cache(app_context, current_user.id, room_db_id)
+
+    status = result.get('status')
+    if status == 'ok':
+        return jsonify({'message': 'Refreshed from Cheese Tracker.'}), 200
+
+    error_map = {
+        'not_connected': ('Not connected to Cheese Tracker.', 400),
+        'no_tracker': ('This room is not linked to Cheese Tracker.', 400),
+        'error': ('Could not reach Cheese Tracker. Please try again.', 502),
+    }
+    message, code = error_map.get(status, ('Could not refresh.', 500))
+    return jsonify({'error': message}), code
+
+
+@slots_bp.route('/rooms/<int:room_db_id>/slots/<int:slot_id>/cheese', methods=['PUT'])
+@handle_db_errors
+@log_api_call
+@token_required
+def update_slot_cheese(current_user, room_db_id, slot_id):
+    """
+    Updates a single slot's Cheese Tracker state (notes / status / ping) and,
+    optionally, refreshes its "last checked" timestamp ("Still BK").
+    Runs synchronously because the user is waiting on the result.
+    """
+    if not current_user.cheese_api_key:
+        return jsonify({'error': 'Not connected to Cheese Tracker.'}), 400
+
+    data = request.json or {}
+
+    # Build a validated partial-update dict. Only include keys the client sent.
+    updates = {}
+    if 'notes' in data:
+        notes = data['notes']
+        if notes is None:
+            notes = ''
+        if not isinstance(notes, str):
+            return jsonify({'error': 'notes must be a string.'}), 400
+        if len(notes) > 5000:
+            return jsonify({'error': 'notes too long (max 5000 characters).'}), 400
+        updates['notes'] = notes
+    if 'progression_status' in data:
+        val = data['progression_status']
+        if val not in VALID_CHEESE_PROGRESSION:
+            return jsonify({'error': 'Invalid progression_status.'}), 400
+        updates['progression_status'] = val
+    if 'completion_status' in data:
+        val = data['completion_status']
+        if val not in VALID_CHEESE_COMPLETION:
+            return jsonify({'error': 'Invalid completion_status.'}), 400
+        updates['completion_status'] = val
+    if 'discord_ping' in data:
+        val = data['discord_ping']
+        if val not in VALID_CHEESE_PING:
+            return jsonify({'error': 'Invalid discord_ping.'}), 400
+        updates['discord_ping'] = val
+    if data.get('touch_last_checked'):
+        updates['touch_last_checked'] = True
+
+    if not updates:
+        return jsonify({'error': 'No valid fields to update.'}), 400
+
+    # Throttle.
+    now = datetime.utcnow()
+    last = _cheese_write_last.get(current_user.id)
+    if last is not None and (now - last) < _CHEESE_WRITE_MIN_INTERVAL:
+        return jsonify({'error': 'Too many updates. Please slow down.'}), 429
+    _cheese_write_last[current_user.id] = now
+
+    from app.api_cheese import apply_cheese_slot_update
+    app_context = current_app._get_current_object()
+    result = apply_cheese_slot_update(app_context, current_user.id, room_db_id, slot_id, updates)
+
+    status = result.get('status')
+    if status == 'ok':
+        my_discord_clean = current_user.discord_username.strip().lower() if current_user.discord_username else None
+        cheese_state = build_cheese_slot_state(
+            result['game'],
+            result.get('global_ping_policy'),
+            current_user.cheese_user_id,
+            my_discord_clean
+        )
+        return jsonify({'message': 'Slot updated.', 'cheese': cheese_state}), 200
+
+    error_map = {
+        'not_connected': ('Not connected to Cheese Tracker.', 400),
+        'no_tracker': ('This room is not linked to Cheese Tracker.', 400),
+        'not_tracked': ('You are not tracking this slot.', 403),
+        'not_found': ('Slot not found on Cheese Tracker.', 404),
+        'forbidden': ('This slot is claimed by someone else on Cheese Tracker.', 403),
+        'conflict': ('This slot changed on Cheese Tracker. Please refresh and try again.', 409),
+        'error': ('Could not reach Cheese Tracker. Please try again.', 502),
+    }
+    message, code = error_map.get(status, ('Could not update slot.', 500))
+    return jsonify({'error': message}), code
+
+
 @slots_bp.route('/users/me/tracked-slots', methods=['GET'])
 @handle_db_errors
 @log_api_call
@@ -184,6 +359,27 @@ def get_user_tracked_slots(current_user):
 
             players_map = {p['slot_id']: p for p in players_json}
 
+            # Parse the room's cached Cheese Tracker data (if any) once per room,
+            # indexed by slot position, so we can attach per-slot Cheese state.
+            # Only build this for users who have connected a Cheese API key.
+            cheese_games_map = {}
+            cheese_global_ping_policy = None
+            room_has_cheese = bool(current_user.cheese_api_key) and bool(room_data.cheese_tracker_id)
+            if room_has_cheese and room_data.cached_cheese_json:
+                try:
+                    cheese_data = json.loads(room_data.cached_cheese_json)
+                    if isinstance(cheese_data, dict):
+                        cheese_global_ping_policy = cheese_data.get('global_ping_policy')
+                        for g in cheese_data.get('games', []):
+                            pos = g.get('position')
+                            if pos is not None:
+                                cheese_games_map[pos] = g
+                except (json.JSONDecodeError, TypeError):
+                    cheese_games_map = {}
+
+            my_cheese_user_id = current_user.cheese_user_id
+            my_discord_clean = current_user.discord_username.strip().lower() if current_user.discord_username else None
+
             tracked_slots_list = []
             for slot in sorted(sub.tracked_slots, key=lambda s: s.slot_id):
                 p_obj = players_map.get(slot.slot_id)
@@ -194,6 +390,16 @@ def get_user_tracked_slots(current_user):
 
                 slot_last_activity = last_activity_map.get((room_data.room_id, slot.slot_id))
                 slot_item_count = item_count_map.get((room_data.room_id, slot.slot_id), 0)
+
+                cheese_state = None
+                cheese_game = cheese_games_map.get(slot.slot_id)
+                if cheese_game is not None:
+                    cheese_state = build_cheese_slot_state(
+                        cheese_game,
+                        cheese_global_ping_policy,
+                        my_cheese_user_id,
+                        my_discord_clean
+                    )
 
                 tracked_slots_list.append({
                     'slot_id': slot.slot_id,
@@ -217,7 +423,8 @@ def get_user_tracked_slots(current_user):
                     'remove_emojis': slot.remove_emojis,
                     'suppress_self_found': slot.suppress_self_found,
                     'suppress_connected': slot.suppress_connected,
-                    'snooze_until': format_iso_z(slot.snooze_until)
+                    'snooze_until': format_iso_z(slot.snooze_until),
+                    'cheese': cheese_state
                 })
 
             response_data.append({

--- a/backend/app/routes/user_routes.py
+++ b/backend/app/routes/user_routes.py
@@ -13,6 +13,10 @@ from app.routes.common import log_api_call, token_required, handle_db_errors, fo
 
 user_bp = Blueprint('user_routes', __name__)
 
+# Valid Cheese Tracker per-user ping preferences (wire values from CT's
+# ping_preference enum). Used to validate cheese_default_ping updates.
+VALID_CHEESE_PING_PREFERENCES = {'liberally', 'sparingly', 'hints', 'see_notes', 'never'}
+
 @user_bp.route('/devices', methods=['POST'])
 @handle_db_errors
 @log_api_call
@@ -129,6 +133,7 @@ def get_current_user(current_user):
             'suppress_self_found_default': current_user.suppress_self_found_default,
             'suppress_connected_default': current_user.suppress_connected_default,
             'is_cheese_connected': current_user.cheese_api_key is not None,
+            'cheese_default_ping': current_user.cheese_default_ping,
             'ui_show_finished_default': current_user.ui_show_finished_default,
             'ui_show_found_hints_default': current_user.ui_show_found_hints_default,
             'ui_show_progression_default': current_user.ui_show_progression_default,
@@ -169,6 +174,7 @@ def get_current_user(current_user):
             'suppress_self_found_default': current_user.suppress_self_found_default,
             'suppress_connected_default': current_user.suppress_connected_default,
             'is_cheese_connected': current_user.cheese_api_key is not None,
+            'cheese_default_ping': current_user.cheese_default_ping,
             'ui_show_finished_default': current_user.ui_show_finished_default,
             'ui_show_found_hints_default': current_user.ui_show_found_hints_default,
             'ui_show_progression_default': current_user.ui_show_progression_default,
@@ -230,6 +236,15 @@ def update_user_preferences(current_user):
             setattr(user, 'suppress_self_found_default', bool(data['suppress_self_found']))
         if 'suppress_connected' in data:
             setattr(user, 'suppress_connected_default', bool(data['suppress_connected']))
+        if 'cheese_default_ping' in data:
+            raw = data['cheese_default_ping']
+            # Empty string / null clears the default (revert to leaving CT's value alone).
+            if raw is None or (isinstance(raw, str) and raw.strip() == ''):
+                user.cheese_default_ping = None
+            elif isinstance(raw, str) and raw.strip().lower() in VALID_CHEESE_PING_PREFERENCES:
+                user.cheese_default_ping = raw.strip().lower()
+            else:
+                return jsonify({'error': 'Invalid cheese_default_ping value.'}), 400
         session.commit()
         return jsonify({'message': 'Preferences updated successfully'}), 200
     except Exception as e:


### PR DESCRIPTION
## Summary

Adds **Cheesetracker Notes & Statuses** to the app. Users synced with Cheese Tracker (CT) can now view and edit their notes and status per slot from the slot detail screen, set a default ping preference on their profile, and refresh CT state on demand.

## Slot detail screen (shown only when the slot is synced with CT)
- Edit **notes**, **progression status** (Unknown / Unblocked / BK / Soft BK / Go Mode) and **completion status** (Incomplete / All Checks / Goal / Done / Forfeit).
- **"Still BK"** button refreshes Last Checked without changing status; setting a BK/Soft BK status also stamps Last Checked — mirroring the CT web UI.
- **Per-slot ping preference** (read-only when the tracker has a global ping policy).
- **Forfeit** shows a confirmation, since it is permanent on CT and cannot be reversed.
- Section is hidden entirely when the slot isn't CT-synced.

## Profile
- **Default ping preference** in the CT integration card, applied at claim time. This fixes ping always defaulting to "Never". Unclaim now aligns with CT web (availability → `open`, ping → `never`).

## Freshness / UX
- Slot detail now fetches tracked slots **on open**, so CT state isn't stale from the last time the Slots list loaded.
- **Pull-to-refresh** and a **refresh icon on the Cheese card** trigger an on-demand, authenticated single-tracker refresh that bypasses the ~5 min background poll.

## Backend
- New `User.cheese_default_ping` column (Alembic `a1c7e9f4b2d0`), exposed on the profile and settable via `PUT /users/me/preferences`.
- Read path attaches a per-slot `cheese` object to `GET /users/me/tracked-slots` (parsed from the cached tracker data; `null` when not CT-linked).
- New `PUT /rooms/<id>/slots/<slot_id>/cheese`: enum validation, ownership checks, `last_checked` stamping, `x-if-owner-is` conflict guard, and cache splice using CT's authoritative response.
- New `POST /rooms/<id>/cheese/refresh`: authenticated single-tracker refresh reusing the poller's processing.
- Per-user throttles on slot writes and refreshes.

## Gotchas handled
- CT's `update_completion_status` force-upgrades completion monotonically (Forfeit is sticky) — the UI reconciles against the server response, not the request echo.
- "Still BK" writes `last_checked`, not `last_activity` (which CT computes and isn't writable).
- Notes/status use full-object PUT with a re-fetch + `x-if-owner-is` guard to avoid silently clobbering concurrent web edits (412 → "refresh and retry").

## Testing
- Backend unit tests cover payload merge, ownership rejection, BK stamping, completion force-upgrade, 412→conflict, and refresh control flow. (Test file is kept local per the repo's `tests/` ignore convention — not included in this PR.)
- Android `compileDevDebugKotlin` passes.

## Notes for reviewers
- `backend/app/data/changelog.json` is `.gitignore`d by the repo, so the 1.6.22 changelog JSON + version bumps are **not** in this PR — they'll need to go through the project's changelog deploy process. `CHANGELOG.md` (tracked) is updated here.
- App version bumped to **1.6.22 / versionCode 65** following the existing patch-bump convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)