### PR TITLE
Fix item-group ignore/whitelist rules not being version-aware or reflected in history

### DIFF
--- a/android/app/src/main/java/com/jones/aptracker/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/jones/aptracker/database/AppDatabase.kt
@@ -11,7 +11,7 @@ import com.jones.aptracker.network.HistoryItemEntity
 import com.jones.aptracker.network.RoomDao
 import com.jones.aptracker.network.RoomEntity
 
-@Database(entities = [RoomEntity::class, HistoryItemEntity::class, HintEntity::class, CachedDatapackageEntity::class], version = 21)
+@Database(entities = [RoomEntity::class, HistoryItemEntity::class, HintEntity::class, CachedDatapackageEntity::class], version = 22)
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun roomDao(): RoomDao
@@ -33,7 +33,8 @@ abstract class AppDatabase : RoomDatabase() {
                     .addMigrations(
                         MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9,
                         MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15,
-                        MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21
+                        MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21,
+                        MIGRATION_21_22
                     )
                     .fallbackToDestructiveMigration()
                     .build()

--- a/android/app/src/main/java/com/jones/aptracker/database/Migrations.kt
+++ b/android/app/src/main/java/com/jones/aptracker/database/Migrations.kt
@@ -246,4 +246,24 @@ val MIGRATION_20_21 = object : Migration(20, 21) {
     override fun migrate(db: SupportSQLiteDatabase) {
         // Schema structure is unchanged; migration triggers reset of SharedPreferences watermarks for sequence sync
     }
+}
+
+/**
+ * Adds server-computed isIgnored/isWhitelisted flags to history_items and hints.
+ * These used to be derived entirely on-device by matching item names against the
+ * ignore/whitelist lists, which couldn't resolve item-group rules (group membership
+ * isn't known to the client). The server now evaluates this using the same logic
+ * as notification filtering and sends the result down directly.
+ *
+ * Existing locally-cached rows default to false until they're next re-synced from
+ * the server; this only affects the ignore/whitelist display state of already-synced
+ * history, not new items.
+ */
+val MIGRATION_21_22 = object : Migration(21, 22) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE history_items ADD COLUMN isIgnored INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("ALTER TABLE history_items ADD COLUMN isWhitelisted INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("ALTER TABLE hints ADD COLUMN isIgnored INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("ALTER TABLE hints ADD COLUMN isWhitelisted INTEGER NOT NULL DEFAULT 0")
+    }
 }

--- a/android/app/src/main/java/com/jones/aptracker/network/ApiService.kt
+++ b/android/app/src/main/java/com/jones/aptracker/network/ApiService.kt
@@ -299,7 +299,9 @@ data class HistoryItem(
     val icon_name: String?,
     val room_db_id: Int?,
     val host: String?,
-    val receivedCount: Int? = null
+    val receivedCount: Int? = null,
+    val isIgnored: Boolean = false,
+    val isWhitelisted: Boolean = false
 )
 
 data class RegisterDeviceRequest(
@@ -467,7 +469,9 @@ data class HintDetail(
     val location_name: String,
     val is_found: Boolean,
     val timestamp: String,
-    val item_flags: Int = 0
+    val item_flags: Int = 0,
+    val isIgnored: Boolean = false,
+    val isWhitelisted: Boolean = false
 )
 
 data class ConfigResponse(

--- a/android/app/src/main/java/com/jones/aptracker/network/HintEntity.kt
+++ b/android/app/src/main/java/com/jones/aptracker/network/HintEntity.kt
@@ -20,5 +20,7 @@ data class HintEntity(
     val locationName: String,
     val isFound: Boolean,
     val timestamp: String,
-    val itemFlags: Int = 0
+    val itemFlags: Int = 0,
+    val isIgnored: Boolean = false,
+    val isWhitelisted: Boolean = false
 )

--- a/android/app/src/main/java/com/jones/aptracker/network/HistoryItemEntity.kt
+++ b/android/app/src/main/java/com/jones/aptracker/network/HistoryItemEntity.kt
@@ -27,5 +27,7 @@ data class HistoryItemEntity(
     val slot_id: Int?,
     val icon_name: String?,
     val host: String?,
-    val receivedCount: Int? = null
+    val receivedCount: Int? = null,
+    val isIgnored: Boolean = false,
+    val isWhitelisted: Boolean = false
 )

--- a/android/app/src/main/java/com/jones/aptracker/repository/HistoryRepository.kt
+++ b/android/app/src/main/java/com/jones/aptracker/repository/HistoryRepository.kt
@@ -165,7 +165,9 @@ class HistoryRepository(
                                     slot_id = item.slot_id,
                                     icon_name = item.icon_name,
                                     host = item.host,
-                                    receivedCount = item.receivedCount
+                                    receivedCount = item.receivedCount,
+                                    isIgnored = item.isIgnored,
+                                    isWhitelisted = item.isWhitelisted
                                 )
                             } catch (e: Exception) {
                                 Log.e("HISTORY_DEBUG", "!!! FAILED to process sync item: ${e.message}")
@@ -258,7 +260,9 @@ class HistoryRepository(
                     slot_id = item.slot_id,
                     icon_name = item.icon_name,
                     host = item.host,
-                    receivedCount = item.receivedCount
+                    receivedCount = item.receivedCount,
+                    isIgnored = item.isIgnored,
+                    isWhitelisted = item.isWhitelisted
                 )
             } catch (e: Exception) {
                 Log.e("HISTORY_DEBUG", "!!! FAILED to process history feed item: ${e.message}")
@@ -306,7 +310,9 @@ class HistoryRepository(
                                 slot_id = item.slot_id,
                                 icon_name = item.icon_name,
                                 host = item.host,
-                                receivedCount = item.receivedCount
+                                receivedCount = item.receivedCount,
+                                isIgnored = item.isIgnored,
+                                isWhitelisted = item.isWhitelisted
                             )
                         } catch (e: Exception) {
                             Log.e("HISTORY_DEBUG", "!!! FAILED to process history item: ${e.message}")
@@ -389,7 +395,9 @@ class HistoryRepository(
             locationName = detail.location_name,
             isFound = detail.is_found,
             timestamp = normalizeTimestamp(detail.timestamp),
-            itemFlags = detail.item_flags
+            itemFlags = detail.item_flags,
+            isIgnored = detail.isIgnored,
+            isWhitelisted = detail.isWhitelisted
         )
     }
 

--- a/android/app/src/main/java/com/jones/aptracker/ui/HistoryScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/HistoryScreen.kt
@@ -110,8 +110,6 @@ import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.jones.aptracker.network.HintEntity
 import com.jones.aptracker.network.HistoryItem
-import com.jones.aptracker.network.IgnoreItem
-import com.jones.aptracker.network.WhitelistItem
 import com.jones.aptracker.ui.theme.APTheme
 import kotlinx.coroutines.launch
 import java.time.Instant
@@ -145,10 +143,8 @@ fun HistoryContent(
     val showFiller by historyViewModel.showFiller.collectAsState()
     val showTrap by historyViewModel.showTrap.collectAsState()
 
-    // Ignored Items filter
+    // Ignored Items filter (isIgnored/isWhitelisted are computed server-side per item)
     val showIgnoredItems by historyViewModel.showIgnoredItems.collectAsState()
-    val ignoreList by userViewModel.ignoreList.collectAsState()
-    val whitelist by userViewModel.whitelist.collectAsState()
 
     val roomNames by historyViewModel.roomNames.collectAsState()
     val selectedItemGroups by historyViewModel.selectedItemGroups.collectAsState()
@@ -187,10 +183,6 @@ fun HistoryContent(
         if (historyViewModel.itemHistory.value.isEmpty()) {
             historyViewModel.refreshAllHistory()
         }
-        // Re-fetch ignore/whitelist on every entry so changes from IgnoreListScreen
-        // and WhitelistScreen are immediately reflected without needing an app restart.
-        userViewModel.fetchIgnoreList()
-        userViewModel.fetchWhitelist()
     }
 
     LaunchedEffect(selectedItem) {
@@ -267,9 +259,7 @@ fun HistoryContent(
                             dateFormatPreset = dateFormatPreset,
                             onItemClick = { selectedItem = it },
                             showRoomFilter = showRoomFilter,
-                            showIgnoredItems = showIgnoredItems,
-                            ignoreList = ignoreList,
-                            whitelist = whitelist
+                            showIgnoredItems = showIgnoredItems
                         )
                         1 -> HintHistoryTab(
                             historyViewModel = historyViewModel,
@@ -278,9 +268,7 @@ fun HistoryContent(
                             dateFormatPreset = dateFormatPreset,
                             onHintClick = { selectedHint = it },
                             showRoomFilter = showRoomFilter,
-                            showIgnoredItems = showIgnoredItems,
-                            ignoreList = ignoreList,
-                            whitelist = whitelist
+                            showIgnoredItems = showIgnoredItems
                         )
                     }
                 }
@@ -883,9 +871,7 @@ fun ItemHistoryTab(
     dateFormatPreset: DateFormatPreset,
     onItemClick: (HistoryItem) -> Unit,
     showRoomFilter: Boolean,
-    showIgnoredItems: Boolean,
-    ignoreList: List<IgnoreItem>,
-    whitelist: List<WhitelistItem> = emptyList()
+    showIgnoredItems: Boolean
 ) {
     val fullHistory by historyViewModel.itemHistory.collectAsState()
     val availablePlayers by historyViewModel.availablePlayers.collectAsState()
@@ -915,66 +901,8 @@ fun ItemHistoryTab(
     // Filter Logic
     val itemsToShow = remember(
         fullHistory, searchQuery, selectedPlayer, showFinished, finishedKeys, historyFilter,
-        activeRoomIds, archivedRoomIds, showProgression, showUseful, showFiller, showTrap, showIgnoredItems, ignoreList, whitelist
+        activeRoomIds, archivedRoomIds, showProgression, showUseful, showFiller, showTrap, showIgnoredItems
     ) {
-        fun String.toWildcardRegex(): Regex {
-            val parts = this.split("*")
-            val sb = StringBuilder()
-            for (i in parts.indices) {
-                if (i > 0) sb.append(".*")
-                val subParts = parts[i].split("?")
-                for (j in subParts.indices) {
-                    if (j > 0) sb.append(".")
-                    if (subParts[j].isNotEmpty()) {
-                        sb.append(Regex.escape(subParts[j]))
-                    }
-                }
-            }
-            return Regex("^${sb.toString()}$", RegexOption.IGNORE_CASE)
-        }
-
-        val globalExact = mutableSetOf<String>()
-        val globalPatterns = mutableListOf<Regex>()
-        val gameExact = mutableMapOf<String, MutableSet<String>>()
-        val gamePatterns = mutableMapOf<String, MutableList<Regex>>()
-
-        ignoreList.forEach { rule ->
-            val cleanItem = rule.itemName.trim()
-            val isWildcard = cleanItem.contains("*") || cleanItem.contains("?")
-            if (rule.gameName.isNullOrBlank()) {
-                if (isWildcard) globalPatterns.add(cleanItem.toWildcardRegex())
-                else globalExact.add(cleanItem.lowercase())
-            } else {
-                val gameLower = rule.gameName.trim().lowercase()
-                if (isWildcard) {
-                    gamePatterns.getOrPut(gameLower) { mutableListOf() }.add(cleanItem.toWildcardRegex())
-                } else {
-                    gameExact.getOrPut(gameLower) { mutableSetOf() }.add(cleanItem.lowercase())
-                }
-            }
-        }
-
-        val wlGlobalExact = mutableSetOf<String>()
-        val wlGlobalPatterns = mutableListOf<Regex>()
-        val wlGameExact = mutableMapOf<String, MutableSet<String>>()
-        val wlGamePatterns = mutableMapOf<String, MutableList<Regex>>()
-
-        whitelist.forEach { rule ->
-            val cleanItem = rule.itemName.trim()
-            val isWildcard = cleanItem.contains("*") || cleanItem.contains("?")
-            if (rule.gameName.isNullOrBlank()) {
-                if (isWildcard) wlGlobalPatterns.add(cleanItem.toWildcardRegex())
-                else wlGlobalExact.add(cleanItem.lowercase())
-            } else {
-                val gameLower = rule.gameName.trim().lowercase()
-                if (isWildcard) {
-                    wlGamePatterns.getOrPut(gameLower) { mutableListOf() }.add(cleanItem.toWildcardRegex())
-                } else {
-                    wlGameExact.getOrPut(gameLower) { mutableSetOf() }.add(cleanItem.lowercase())
-                }
-            }
-        }
-
         fullHistory.filter { item ->
             val matchesSearch = searchQuery.isBlank() ||
                     item.playerName.contains(searchQuery, ignoreCase = true) ||
@@ -996,19 +924,6 @@ fun ItemHistoryTab(
             }
             val matchesFinished = showFinished || !isFinished
 
-            val cleanItemName = item.itemName.trim()
-            val lowerCaseItemName = cleanItemName.lowercase()
-            val lowerCaseGameName = item.receivingGame?.trim()?.lowercase()
-
-            var isWhitelisted = lowerCaseItemName in wlGlobalExact || wlGlobalPatterns.any { it.matches(cleanItemName) }
-            if (!isWhitelisted && lowerCaseGameName != null) {
-                if (wlGameExact[lowerCaseGameName]?.contains(lowerCaseItemName) == true) {
-                    isWhitelisted = true
-                } else if (wlGamePatterns[lowerCaseGameName]?.any { it.matches(cleanItemName) } == true) {
-                    isWhitelisted = true
-                }
-            }
-
             // --- TYPE CHECK (Prioritized to match visual colors) ---
             val isProgression = (item.itemFlags and 1) != 0
             val isUseful = (item.itemFlags and 2) != 0
@@ -1024,18 +939,10 @@ fun ItemHistoryTab(
                 showFiller
             }
 
-            var isIgnored = lowerCaseItemName in globalExact || globalPatterns.any { it.matches(cleanItemName) }
-
-            if (!isIgnored && lowerCaseGameName != null) {
-                if (gameExact[lowerCaseGameName]?.contains(lowerCaseItemName) == true) {
-                    isIgnored = true
-                } else if (gamePatterns[lowerCaseGameName]?.any { it.matches(cleanItemName) } == true) {
-                    isIgnored = true
-                }
-            }
-
-            val matchesCategoryOrWhitelist = isWhitelisted || matchesType
-            val matchesIgnoredOrWhitelist = isWhitelisted || (showIgnoredItems || !isIgnored)
+            // isIgnored/isWhitelisted are computed server-side (see history_routes.py),
+            // since item-group membership isn't known to the client.
+            val matchesCategoryOrWhitelist = item.isWhitelisted || matchesType
+            val matchesIgnoredOrWhitelist = item.isWhitelisted || (showIgnoredItems || !item.isIgnored)
 
             matchesSearch && matchesRoom && matchesPlayer && matchesFinished && matchesCategoryOrWhitelist && matchesIgnoredOrWhitelist
         }
@@ -1353,9 +1260,7 @@ fun HintHistoryTab(
     dateFormatPreset: DateFormatPreset,
     onHintClick: (HintEntity) -> Unit,
     showRoomFilter: Boolean,
-    showIgnoredItems: Boolean,
-    ignoreList: List<IgnoreItem>,
-    whitelist: List<WhitelistItem> = emptyList()
+    showIgnoredItems: Boolean
 ) {
     val hintsForYou by historyViewModel.hintsForYou.collectAsState()
     val hintsByYou by historyViewModel.hintsByYou.collectAsState()
@@ -1387,23 +1292,23 @@ fun HintHistoryTab(
     val filteredHintsForYou = remember(
         hintsForYou, searchQuery, showFinished, finishedKeys, selectedPlayer,
         historyFilter, activeRoomIds, archivedRoomIds,
-        showProgression, showUseful, showFiller, showTrap, showIgnoredItems, ignoreList, whitelist
+        showProgression, showUseful, showFiller, showTrap, showIgnoredItems
     ) {
         filterHints(
             hintsForYou, searchQuery, showFinished, finishedKeys, selectedPlayer,
             historyFilter, activeRoomIds, archivedRoomIds,
-            showProgression, showUseful, showFiller, showTrap, showIgnoredItems, ignoreList, whitelist
+            showProgression, showUseful, showFiller, showTrap, showIgnoredItems
         )
     }
     val filteredHintsByYou = remember(
         hintsByYou, searchQuery, showFinished, finishedKeys, selectedPlayer,
         historyFilter, activeRoomIds, archivedRoomIds,
-        showProgression, showUseful, showFiller, showTrap, showIgnoredItems, ignoreList, whitelist
+        showProgression, showUseful, showFiller, showTrap, showIgnoredItems
     ) {
         filterHints(
             hintsByYou, searchQuery, showFinished, finishedKeys, selectedPlayer,
             historyFilter, activeRoomIds, archivedRoomIds,
-            showProgression, showUseful, showFiller, showTrap, showIgnoredItems, ignoreList, whitelist
+            showProgression, showUseful, showFiller, showTrap, showIgnoredItems
         )
     }
 
@@ -1737,44 +1642,8 @@ private fun filterHints(
     showUseful: Boolean,
     showFiller: Boolean,
     showTrap: Boolean,
-    showIgnoredItems: Boolean,
-    ignoreList: List<IgnoreItem>,
-    whitelist: List<WhitelistItem> = emptyList()
+    showIgnoredItems: Boolean
 ): List<HintEntity> {
-    fun String.toWildcardRegex(): Regex {
-        val parts = this.split("*")
-        val sb = StringBuilder()
-        for (i in parts.indices) {
-            if (i > 0) sb.append(".*")
-            val subParts = parts[i].split("?")
-            for (j in subParts.indices) {
-                if (j > 0) sb.append(".")
-                if (subParts[j].isNotEmpty()) {
-                    sb.append(Regex.escape(subParts[j]))
-                }
-            }
-        }
-        return Regex("^${sb.toString()}$", RegexOption.IGNORE_CASE)
-    }
-
-    val exactNames = mutableSetOf<String>()
-    val patternNames = mutableListOf<Regex>()
-
-    ignoreList.forEach { rule ->
-        val isWildcard = rule.itemName.contains("*") || rule.itemName.contains("?")
-        if (isWildcard) patternNames.add(rule.itemName.toWildcardRegex())
-        else exactNames.add(rule.itemName.lowercase())
-    }
-
-    val wlExactNames = mutableSetOf<String>()
-    val wlPatternNames = mutableListOf<Regex>()
-
-    whitelist.forEach { rule ->
-        val isWildcard = rule.itemName.contains("*") || rule.itemName.contains("?")
-        if (isWildcard) wlPatternNames.add(rule.itemName.toWildcardRegex())
-        else wlExactNames.add(rule.itemName.lowercase())
-    }
-
     return hints.filter { hint ->
         // 1. Room Check
         val matchesRoom = when (val f = historyFilter) {
@@ -1803,9 +1672,6 @@ private fun filterHints(
             }
         }
 
-        val lowerCaseItemName = hint.itemName.lowercase()
-        val isWhitelisted = lowerCaseItemName in wlExactNames || wlPatternNames.any { it.matches(hint.itemName) }
-
         // --- TYPE CHECK (Prioritized to match visual colors) ---
         val isProgression = (hint.itemFlags and 1) != 0
         val isUseful = (hint.itemFlags and 2) != 0
@@ -1821,10 +1687,10 @@ private fun filterHints(
             showFiller
         }
 
-        // Note: HintEntity does not have receivingGame, so we just match on itemName
-        val isIgnored = lowerCaseItemName in exactNames || patternNames.any { it.matches(hint.itemName) }
-        val matchesCategoryOrWhitelist = isWhitelisted || matchesType
-        val matchesIgnoredOrWhitelist = isWhitelisted || (showIgnoredItems || !isIgnored)
+        // isIgnored/isWhitelisted are computed server-side (see history_routes.py),
+        // since item-group membership isn't known to the client.
+        val matchesCategoryOrWhitelist = hint.isWhitelisted || matchesType
+        val matchesIgnoredOrWhitelist = hint.isWhitelisted || (showIgnoredItems || !hint.isIgnored)
 
         matchesRoom && matchesQuery && matchesFinished && matchesPlayer && matchesCategoryOrWhitelist && matchesIgnoredOrWhitelist
     }

--- a/android/app/src/main/java/com/jones/aptracker/ui/HistoryViewModel.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/HistoryViewModel.kt
@@ -622,7 +622,9 @@ class HistoryViewModel(application: Application) : AndroidViewModel(application)
                 senderAlias = entity.senderAlias,
                 senderGame = entity.senderGame,
                 locationName = entity.locationName,
-                receivedCount = entity.receivedCount
+                receivedCount = entity.receivedCount,
+                isIgnored = entity.isIgnored,
+                isWhitelisted = entity.isWhitelisted
             )
         }
         return result

--- a/backend/app/poller.py
+++ b/backend/app/poller.py
@@ -29,6 +29,7 @@ from .models import (
 )
 from .utils import get_user_agent_string, get_cheese_headers, extract_ap_room_id, fetch_json_with_status, db_suspend_room, is_snoozed, SSRFProtectedTCPConnector, generate_negative_id
 from app.services.redis_service import get_redis_client, publish_event
+from app.services.filtering_service import fetch_group_members_lookup, evaluate_item_filter_status
 
 from . import POLLING_INTERVAL_SECONDS, SUPERVISOR_INTERVAL_SECONDS
 
@@ -585,25 +586,7 @@ def _resolve_names_and_notify(session, room_db_id, room_uuid, game_checksums, ca
     group_members_lookup = set()
     if new_items_for_notify:
         checksums = {item['game_checksum'] for item in new_items_for_notify if item.get('game_checksum')}
-        if checksums:
-            try:
-                member_results = session.query(DatapackageCache.checksum, DatapackageCache.entity_name).filter(
-                    DatapackageCache.checksum.in_(checksums),
-                    DatapackageCache.entity_type == 'item_name_groups_json'
-                ).all()
-                for chk, name_groups_str in member_results:
-                    try:
-                        parsed_data = json.loads(name_groups_str)
-                        if isinstance(parsed_data, dict):
-                            for g_name, items in parsed_data.items():
-                                if isinstance(items, list):
-                                    g_name_lower = g_name.lower().strip()
-                                    for item in items:
-                                        group_members_lookup.add((chk, (g_name_lower, item.lower().strip())))
-                    except Exception:
-                        pass
-            except Exception as e:
-                logging.error(f"[POLLER_DB_ERROR] Failed to fetch group members: {e}")
+        group_members_lookup = fetch_group_members_lookup(session, checksums)
 
     # 1. Fetch Names from DatapackageCache
     if cache_keys_to_fetch:
@@ -678,8 +661,6 @@ def _resolve_names_and_notify(session, room_db_id, room_uuid, game_checksums, ca
                     logging.debug(f"[NOTIFY_SKIP][RoomDBID:{room_db_id}] User {user_id} tracking Slot {rid} is backfilling. Suppressing item {item_data['item_id']}.")
                     continue
 
-                normalized_item_name = item_name.lower().strip()
-
                 # --- PREFERENCE-BASED SUPPRESSION ---
                 if True:
                     suppress_own = get_pref('suppress_own_events', 'suppress_own_events_default')
@@ -712,58 +693,22 @@ def _resolve_names_and_notify(session, room_db_id, room_uuid, game_checksums, ca
                 receiver_alias = short_name_map.get(rid, f"Slot {rid}")
                 receiver_original = full_name_map.get(rid, f"Slot {rid}")
 
-                # --- WHITELIST CHECK ---
-                is_whitelisted = False
-                if getattr(user_prefs, 'whitelist_items', None):
-                    for whitelist_rule in user_prefs.whitelist_items:
-                        rule_pattern = whitelist_rule.item_name.lower().strip()
-                        if getattr(whitelist_rule, 'is_group', False):
-                            # Group whitelist: Only supports game-specific level
-                            if whitelist_rule.game_name and whitelist_rule.game_name.lower().strip() == item_data['receiver_game'].lower().strip():
-                                lookup_key = (item_data['game_checksum'], (rule_pattern, normalized_item_name))
-                                if lookup_key in group_members_lookup:
-                                    is_whitelisted = True
-                                    break
-                        else:
-                            # Single item whitelist (supports wildcard matching)
-                            if fnmatch.fnmatch(normalized_item_name, rule_pattern):
-                                if not whitelist_rule.game_name:
-                                    is_whitelisted = True
-                                    break
-                                elif whitelist_rule.game_name.lower().strip() == item_data['receiver_game'].lower().strip():
-                                    is_whitelisted = True
-                                    break
+                # --- WHITELIST / IGNORE CHECK ---
+                should_ignore, is_whitelisted, matched_ignore_rule, _ = evaluate_item_filter_status(
+                    item_name=item_name,
+                    game_name=item_data['receiver_game'],
+                    game_checksum=item_data['game_checksum'],
+                    ignore_items=user_prefs.ignore_items,
+                    whitelist_items=user_prefs.whitelist_items,
+                    group_members_lookup=group_members_lookup
+                )
 
                 if is_whitelisted:
                     logging.info(f"[NOTIFY_WHITELISTED] User {user_id} whitelisted item '{item_name}' for game '{item_data['receiver_game']}'.")
 
-                # --- IGNORE LIST CHECK ---
-                if not is_whitelisted:
-                    should_ignore = False
-                    if user_prefs.ignore_items:
-                        for ignore_rule in user_prefs.ignore_items:
-                            rule_pattern = ignore_rule.item_name.lower().strip()
-                            if getattr(ignore_rule, 'is_group', False):
-                                # Group ignore: Only supports game-specific level
-                                if ignore_rule.game_name and ignore_rule.game_name.lower().strip() == item_data['receiver_game'].lower().strip():
-                                    # Check if the item belongs to this group
-                                    lookup_key = (item_data['game_checksum'], (rule_pattern, normalized_item_name))
-                                    if lookup_key in group_members_lookup:
-                                        should_ignore = True
-                                        break
-                            else:
-                                # Single item ignore (supports wildcard matching)
-                                if fnmatch.fnmatch(normalized_item_name, rule_pattern):
-                                    if not ignore_rule.game_name:
-                                        should_ignore = True
-                                        break
-                                    elif ignore_rule.game_name.lower().strip() == item_data['receiver_game'].lower().strip():
-                                        should_ignore = True
-                                        break
-                    
-                    if should_ignore:
-                        logging.info(f"[NOTIFY_SUPPRESSED] User {user_id} ignored item '{item_name}' (matched rule '{rule_pattern}' is_group={getattr(ignore_rule, 'is_group', False)}) for game '{item_data['receiver_game']}'.")
-                        continue
+                if should_ignore:
+                    logging.info(f"[NOTIFY_SUPPRESSED] User {user_id} ignored item '{item_name}' (matched rule '{matched_ignore_rule.item_name}' is_group={getattr(matched_ignore_rule, 'is_group', False)}) for game '{item_data['receiver_game']}'.")
+                    continue
 
                 # --- CONDENSED MESSAGING CHECK ---
                 use_condensed = user_prefs.use_condensed_messages_default

--- a/backend/app/routes/history_routes.py
+++ b/backend/app/routes/history_routes.py
@@ -8,10 +8,11 @@ from sqlalchemy import or_, desc, tuple_, func
 
 from app import Session
 from app.models import (
-    TrackedRoom, UserRoomSubscription, UserTrackedSlot,
+    User, TrackedRoom, UserRoomSubscription, UserTrackedSlot,
     DatapackageCache, NotifiedItem, NotifiedHint, SlotItemCount
 )
 from app.routes.common import log_api_call, token_required, handle_db_errors, format_iso_z
+from app.services.filtering_service import fetch_group_members_lookup, evaluate_item_filter_status
 
 history_bp = Blueprint('history_routes', __name__)
 
@@ -23,6 +24,12 @@ def process_hints_for_user(session, user_id, room_db_id=None, since_timestamp=No
     user_tracked_tuples = {(ts.room_id, ts.slot_id) for ts in tracked_slots_query.all()}
     if not user_tracked_tuples:
         return {"hints_for_you": [], "hints_by_you": []}
+
+    user_obj = session.query(User).options(
+        selectinload(User.ignore_items), selectinload(User.whitelist_items)
+    ).filter_by(id=user_id).first()
+    ignore_items = user_obj.ignore_items if user_obj else []
+    whitelist_items = user_obj.whitelist_items if user_obj else []
 
     room_map_query = session.query(TrackedRoom.id, TrackedRoom.room_id)
     if room_db_id:
@@ -135,7 +142,9 @@ def process_hints_for_user(session, user_id, room_db_id=None, since_timestamp=No
             "item_owner_name": item_owner_name,
             "location_owner_name": location_owner_name,
             "item_name_key": item_name_key,
-            "location_name_key": location_name_key
+            "location_name_key": location_name_key,
+            "item_owner_game": item_owner_game,
+            "item_checksum": item_checksum
         })
 
     name_cache_map = {}
@@ -157,12 +166,25 @@ def process_hints_for_user(session, user_id, room_db_id=None, since_timestamp=No
             for c in cache_query.all()
         }
 
+    group_members_lookup = fetch_group_members_lookup(
+        session, (t["item_checksum"] for t in temp_hint_data if t.get("item_checksum"))
+    )
+
     for temp_data in temp_hint_data:
         hint = temp_data["hint_obj"]
         current_room_db_id = temp_data["room_db_id"]
         player_map = player_map_by_room.get(current_room_db_id, {})
         item_name = name_cache_map.get(temp_data["item_name_key"]) or f"Item ID {hint.item_id}"
         location_name = name_cache_map.get(temp_data["location_name_key"]) or f"Location ID {hint.location_id}"
+
+        is_ignored, is_whitelisted, _, _ = evaluate_item_filter_status(
+            item_name=item_name,
+            game_name=temp_data["item_owner_game"],
+            game_checksum=temp_data["item_checksum"],
+            ignore_items=ignore_items,
+            whitelist_items=whitelist_items,
+            group_members_lookup=group_members_lookup
+        )
         io_obj = player_map.get(hint.item_owner_id)
         lo_obj = player_map.get(hint.location_owner_id)
 
@@ -192,9 +214,11 @@ def process_hints_for_user(session, user_id, room_db_id=None, since_timestamp=No
             "location_name": location_name,
             "is_found": getattr(hint, 'is_found', False),
             "timestamp": ts_val,
-            "item_flags": getattr(hint, 'item_flags', 0)
+            "item_flags": getattr(hint, 'item_flags', 0),
+            "isIgnored": is_ignored,
+            "isWhitelisted": is_whitelisted
         }
-        
+
         if temp_data["is_item_owner_tracked"]:
             hints_for_you.append(hint_data)
         else:
@@ -317,10 +341,10 @@ def get_item_history(current_user, room_db_id):
             "id": item.id,
             "playerName": receiver_name,
             "playerAlias": receiver_alias,
-            "receivingGame": receiver_game, 
-            "senderName": sender_name,    
+            "receivingGame": receiver_game,
+            "senderName": sender_name,
             "senderAlias": sender_alias,
-            "senderGame": sender_game,   
+            "senderGame": sender_game,
             "timestamp": format_iso_z(item.timestamp),
             "tracker_id": room.tracker_id,
             "slot_id": receiver_id,
@@ -331,6 +355,7 @@ def get_item_history(current_user, room_db_id):
             "_loc_name_key": location_name_key,
             "_raw_item_id": item.item_id,
             "_raw_loc_id": item.location_id,
+            "_game_checksum": rec_checksum,
             "receivedCount": item_counts.get((item.room_id, item.receiving_slot_id, item.item_id), 0)
         })
 
@@ -353,21 +378,40 @@ def get_item_history(current_user, room_db_id):
             for c in cache_query.all()
         }
 
+    group_members_lookup = fetch_group_members_lookup(
+        session, (t["_game_checksum"] for t in history_pre_cache if t.get("_game_checksum"))
+    )
+    # current_user is detached (expunged in token_required), so relationships must be re-queried.
+    prefs_user = session.query(User).options(
+        selectinload(User.ignore_items), selectinload(User.whitelist_items)
+    ).filter_by(id=current_user.id).first()
+    ignore_items = prefs_user.ignore_items if prefs_user else []
+    whitelist_items = prefs_user.whitelist_items if prefs_user else []
+
     history = []
     for temp_item in history_pre_cache:
         item_name = name_cache_map.get(temp_item["_item_name_key"]) or f"Item ID {temp_item['_raw_item_id']}"
         location_name = name_cache_map.get(temp_item["_loc_name_key"]) or f"Location ID {temp_item['_raw_loc_id']}"
-        
+
+        is_ignored, is_whitelisted, _, _ = evaluate_item_filter_status(
+            item_name=item_name,
+            game_name=temp_item["receivingGame"],
+            game_checksum=temp_item["_game_checksum"],
+            ignore_items=ignore_items,
+            whitelist_items=whitelist_items,
+            group_members_lookup=group_members_lookup
+        )
+
         history.append({
             "id": temp_item["id"],
             "playerName": temp_item["playerName"],
             "playerAlias": temp_item["playerAlias"],
-            "receivingGame": temp_item["receivingGame"], 
+            "receivingGame": temp_item["receivingGame"],
             "itemName": item_name,
-            "senderName": temp_item["senderName"],       
+            "senderName": temp_item["senderName"],
             "senderAlias": temp_item["senderAlias"],
-            "senderGame": temp_item["senderGame"],       
-            "locationName": location_name,               
+            "senderGame": temp_item["senderGame"],
+            "locationName": location_name,
             "isPlayerFinished": temp_item["isPlayerFinished"],
             "itemFlags": temp_item["itemFlags"],
             "timestamp": temp_item["timestamp"],
@@ -375,7 +419,9 @@ def get_item_history(current_user, room_db_id):
             "tracker_id": temp_item["tracker_id"],
             "slot_id": temp_item["slot_id"],
             "host": temp_item["host"],
-            "receivedCount": temp_item["receivedCount"]
+            "receivedCount": temp_item["receivedCount"],
+            "isIgnored": is_ignored,
+            "isWhitelisted": is_whitelisted
         })
 
     return jsonify(history)
@@ -638,6 +684,28 @@ def sync_history(current_user):
             for c in cache_query.all()
         }
 
+    filter_checksums = set()
+    for item in items:
+        meta = parsed_room_metadata.get(item.room_id, {})
+        receiver_game = meta.get('game_map', {}).get(item.receiving_slot_id, "Unknown")
+        rec_checksum = meta.get('game_checksums', {}).get(receiver_game)
+        if rec_checksum:
+            filter_checksums.add(rec_checksum)
+    for hint in hints:
+        meta = parsed_room_metadata.get(hint.room_id, {})
+        io_game = meta.get('game_map', {}).get(hint.item_owner_id, "Unknown")
+        io_checksum = meta.get('game_checksums', {}).get(io_game)
+        if io_checksum:
+            filter_checksums.add(io_checksum)
+
+    group_members_lookup = fetch_group_members_lookup(session, filter_checksums)
+    # current_user is detached (expunged in token_required), so relationships must be re-queried.
+    prefs_user = session.query(User).options(
+        selectinload(User.ignore_items), selectinload(User.whitelist_items)
+    ).filter_by(id=current_user.id).first()
+    ignore_items = prefs_user.ignore_items if prefs_user else []
+    whitelist_items = prefs_user.whitelist_items if prefs_user else []
+
     response_items = []
     for item in items:
         room_data = room_map_by_uuid.get(item.room_id)
@@ -672,7 +740,16 @@ def sync_history(current_user):
         
         item_name = name_cache_map.get((rec_checksum, 'item', item.item_id)) or f"Item ID {item.item_id}"
         location_name = name_cache_map.get((snd_checksum, 'location', item.location_id)) or f"Location ID {item.location_id}"
-        
+
+        is_ignored, is_whitelisted, _, _ = evaluate_item_filter_status(
+            item_name=item_name,
+            game_name=receiver_game,
+            game_checksum=rec_checksum,
+            ignore_items=ignore_items,
+            whitelist_items=whitelist_items,
+            group_members_lookup=group_members_lookup
+        )
+
         response_items.append({
             "id": item.id,
             "room_db_id": room_data.id,
@@ -692,7 +769,9 @@ def sync_history(current_user):
             "tracker_id": room_data.tracker_id,
             "slot_id": receiver_id,
             "host": room_data.hostname,
-            "receivedCount": item_counts.get((item.room_id, item.receiving_slot_id, item.item_id), 0)
+            "receivedCount": item_counts.get((item.room_id, item.receiving_slot_id, item.item_id), 0),
+            "isIgnored": is_ignored,
+            "isWhitelisted": is_whitelisted
         })
 
     response_hints = []
@@ -727,7 +806,16 @@ def sync_history(current_user):
         
         item_name = name_cache_map.get((io_checksum, 'item', hint.item_id)) or f"Item ID {hint.item_id}"
         location_name = name_cache_map.get((lo_checksum, 'location', hint.location_id)) or f"Location ID {hint.location_id}"
-        
+
+        is_ignored, is_whitelisted, _, _ = evaluate_item_filter_status(
+            item_name=item_name,
+            game_name=io_game,
+            game_checksum=io_checksum,
+            ignore_items=ignore_items,
+            whitelist_items=whitelist_items,
+            group_members_lookup=group_members_lookup
+        )
+
         response_hints.append({
             "id": hint.id,
             "room_db_id": room_data.id,
@@ -743,7 +831,9 @@ def sync_history(current_user):
             "is_found": hint.is_found,
             "timestamp": format_iso_z(hint.timestamp),
             "updated_at": format_iso_z(hint.updated_at),
-            "item_flags": hint.item_flags or 0
+            "item_flags": hint.item_flags or 0,
+            "isIgnored": is_ignored,
+            "isWhitelisted": is_whitelisted
         })
 
     max_item_ids = {}
@@ -994,6 +1084,7 @@ def get_global_item_history(current_user):
             "_loc_name_key": location_name_key,
             "_raw_item_id": item.item_id,
             "_raw_loc_id": item.location_id,
+            "_game_checksum": rec_checksum,
             "isPlayerFinished": is_finished,
             "itemFlags": item.item_flags or 0,
             "receivedCount": item_counts.get((item.room_id, item.receiving_slot_id, item.item_id), 0)
@@ -1019,30 +1110,51 @@ def get_global_item_history(current_user):
             for c in cache_query.all()
         }
 
+    group_members_lookup = fetch_group_members_lookup(
+        session, (t["_game_checksum"] for t in history_pre_cache if t.get("_game_checksum"))
+    )
+    # current_user is detached (expunged in token_required), so relationships must be re-queried.
+    prefs_user = session.query(User).options(
+        selectinload(User.ignore_items), selectinload(User.whitelist_items)
+    ).filter_by(id=current_user.id).first()
+    ignore_items = prefs_user.ignore_items if prefs_user else []
+    whitelist_items = prefs_user.whitelist_items if prefs_user else []
+
     for temp_item in history_pre_cache:
         item_name = name_cache_map.get(temp_item["_item_name_key"]) or f"Item ID {temp_item['_raw_item_id']}"
         location_name = name_cache_map.get(temp_item["_loc_name_key"]) or f"Location ID {temp_item['_raw_loc_id']}"
 
+        is_ignored, is_whitelisted, _, _ = evaluate_item_filter_status(
+            item_name=item_name,
+            game_name=temp_item["receivingGame"],
+            game_checksum=temp_item["_game_checksum"],
+            ignore_items=ignore_items,
+            whitelist_items=whitelist_items,
+            group_members_lookup=group_members_lookup
+        )
+
         final_history_dicts.append({
             "id": temp_item["id"],
-            "room_db_id": temp_item["room_db_id"], 
-            "alias": temp_item["room_alias"], 
+            "room_db_id": temp_item["room_db_id"],
+            "alias": temp_item["room_alias"],
             "icon_name": temp_item["icon_name"],
             "playerName": temp_item['playerName'],
             "playerAlias": temp_item['playerAlias'],
             "receivingGame": temp_item['receivingGame'],
             "itemName": item_name,
-            "senderName": temp_item['senderName'],     
+            "senderName": temp_item['senderName'],
             "senderAlias": temp_item['senderAlias'],
-            "senderGame": temp_item['senderGame'],      
-            "locationName": location_name,              
+            "senderGame": temp_item['senderGame'],
+            "locationName": location_name,
             "isPlayerFinished": temp_item['isPlayerFinished'],
             "itemFlags": temp_item['itemFlags'],
             "timestamp": temp_item["timestamp"],
             "tracker_id": temp_item["tracker_id"],
             "slot_id": temp_item["slot_id"],
             "host": temp_item["host"],
-            "receivedCount": temp_item["receivedCount"]
+            "receivedCount": temp_item["receivedCount"],
+            "isIgnored": is_ignored,
+            "isWhitelisted": is_whitelisted
         })
 
     return jsonify(final_history_dicts)

--- a/backend/app/services/filtering_service.py
+++ b/backend/app/services/filtering_service.py
@@ -1,0 +1,104 @@
+import json
+import logging
+import fnmatch
+
+from app.models import DatapackageCache
+
+
+def fetch_group_members_lookup(session, checksums):
+    """
+    Builds a set of (checksum, (group_name_lower, item_name_lower)) tuples describing
+    item-group membership for the given datapackage checksums. Used to resolve
+    game-specific item-group ignore/whitelist rules against the specific version
+    (checksum) an item was actually received under.
+    """
+    group_members_lookup = set()
+    checksums = {c for c in checksums if c}
+    if not checksums:
+        return group_members_lookup
+
+    try:
+        member_results = session.query(
+            DatapackageCache.checksum, DatapackageCache.entity_name
+        ).filter(
+            DatapackageCache.checksum.in_(checksums),
+            DatapackageCache.entity_type == 'item_name_groups_json'
+        ).all()
+        for chk, name_groups_str in member_results:
+            try:
+                parsed_data = json.loads(name_groups_str)
+                if isinstance(parsed_data, dict):
+                    for g_name, items in parsed_data.items():
+                        if isinstance(items, list):
+                            g_name_lower = g_name.lower().strip()
+                            for item in items:
+                                group_members_lookup.add((chk, (g_name_lower, item.lower().strip())))
+            except Exception:
+                pass
+    except Exception as e:
+        logging.error(f"[FILTER_DB_ERROR] Failed to fetch group members: {e}")
+
+    return group_members_lookup
+
+
+def evaluate_item_filter_status(item_name, game_name, game_checksum, ignore_items, whitelist_items, group_members_lookup):
+    """
+    Determines whether a single item is ignored and/or whitelisted for a user, given
+    the item's name, the game it belongs to, and the datapackage checksum in effect
+    when it was received (item groups are version-specific, so the checksum matters).
+
+    Single-item rules match by name (optionally wildcarded) and are version-tolerant.
+    Group rules require a game and are resolved against group_members_lookup for the
+    specific checksum, since group membership can differ between versions of a game.
+
+    Returns (is_ignored, is_whitelisted, matched_ignore_rule, matched_whitelist_rule).
+    """
+    normalized_item_name = (item_name or '').lower().strip()
+    normalized_game_name = (game_name or '').lower().strip()
+
+    is_whitelisted = False
+    matched_whitelist_rule = None
+    for rule in (whitelist_items or []):
+        rule_pattern = rule.item_name.lower().strip()
+        if getattr(rule, 'is_group', False):
+            if rule.game_name and rule.game_name.lower().strip() == normalized_game_name:
+                lookup_key = (game_checksum, (rule_pattern, normalized_item_name))
+                if lookup_key in group_members_lookup:
+                    is_whitelisted = True
+                    matched_whitelist_rule = rule
+                    break
+        else:
+            if fnmatch.fnmatch(normalized_item_name, rule_pattern):
+                if not rule.game_name:
+                    is_whitelisted = True
+                    matched_whitelist_rule = rule
+                    break
+                elif rule.game_name.lower().strip() == normalized_game_name:
+                    is_whitelisted = True
+                    matched_whitelist_rule = rule
+                    break
+
+    is_ignored = False
+    matched_ignore_rule = None
+    if not is_whitelisted:
+        for rule in (ignore_items or []):
+            rule_pattern = rule.item_name.lower().strip()
+            if getattr(rule, 'is_group', False):
+                if rule.game_name and rule.game_name.lower().strip() == normalized_game_name:
+                    lookup_key = (game_checksum, (rule_pattern, normalized_item_name))
+                    if lookup_key in group_members_lookup:
+                        is_ignored = True
+                        matched_ignore_rule = rule
+                        break
+            else:
+                if fnmatch.fnmatch(normalized_item_name, rule_pattern):
+                    if not rule.game_name:
+                        is_ignored = True
+                        matched_ignore_rule = rule
+                        break
+                    elif rule.game_name.lower().strip() == normalized_game_name:
+                        is_ignored = True
+                        matched_ignore_rule = rule
+                        break
+
+    return is_ignored, is_whitelisted, matched_ignore_rule, matched_whitelist_rule

--- a/backend/tests/test_history_ignore_filtering.py
+++ b/backend/tests/test_history_ignore_filtering.py
@@ -1,0 +1,208 @@
+import os
+import sys
+import unittest
+import json
+import jwt
+import tempfile
+from datetime import datetime, timezone, timedelta
+
+# Create a unique temporary DB for this test process
+temp_db_file = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+TEST_DB_PATH = temp_db_file.name
+temp_db_file.close()
+
+os.environ['DATABASE_URL'] = f'sqlite:///{TEST_DB_PATH}'
+os.environ['FLASK_ENV'] = 'development'
+os.environ['ENCRYPTION_KEY'] = 'gL1S6v-5D0_l3ZtIox0zVwXyZ3-4VbCdeFghIjklMno='
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, Session, engine
+from app.models import (
+    Base, NotifiedItem, UserTrackedSlot, TrackedRoom, DatapackageCache,
+    User, UserRoomSubscription, UserIgnoreItem, UserWhitelistItem
+)
+
+
+class TestHistoryIgnoreFiltering(unittest.TestCase):
+    """
+    Regression coverage for the "isIgnored"/"isWhitelisted" flags on history
+    responses. Previously the ignore/whitelist toggle was evaluated entirely
+    client-side by matching item names, so item-group rules (which have no
+    client-visible membership data) never matched anything in history, even
+    though they correctly suppressed notifications server-side. The server
+    now computes these flags directly using the same logic as the poller.
+    """
+
+    def setUp(self):
+        self.app = create_app()
+        self.client = self.app.test_client()
+        Base.metadata.drop_all(bind=engine)
+        Base.metadata.create_all(bind=engine)
+        self.session = Session()
+
+    def tearDown(self):
+        self.session.close()
+        Session.remove()
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(TEST_DB_PATH):
+            try:
+                os.remove(TEST_DB_PATH)
+            except Exception:
+                pass
+
+    def _generate_token(self, user_id):
+        payload = {
+            'user_id': user_id,
+            'iat': datetime.now(timezone.utc),
+            'exp': datetime.now(timezone.utc) + timedelta(days=1),
+            'jti': 'test-jti-ignore-filter'
+        }
+        secret = self.app.config['SECRET_KEY']
+        return jwt.encode(payload, secret, algorithm='HS256')
+
+    def _make_room_and_user(self, checksum="checksumA"):
+        room = TrackedRoom(
+            room_id="ignore-filter-room-uuid",
+            tracker_id="test_tracker",
+            hostname="archipelago.gg",
+            game_checksums_json=json.dumps({"Zelda": checksum}),
+            cached_players_json=json.dumps([{"slot_id": 1, "name": "Player1", "game": "Zelda"}])
+        )
+        self.session.add(room)
+        self.session.flush()
+
+        user = User(discord_id="88888", discord_username="ignorefiltertestuser")
+        self.session.add(user)
+        self.session.flush()
+
+        sub = UserRoomSubscription(user_id=user.id, room_id=room.id, alias="Ignore Filter Room")
+        self.session.add(sub)
+
+        slot = UserTrackedSlot(user_id=user.id, room_id=room.id, slot_id=1)
+        self.session.add(slot)
+        self.session.commit()
+
+        return room, user
+
+    def _add_item_datapackage(self, checksum, item_id, item_name, group_name=None):
+        self.session.add(DatapackageCache(
+            game="Zelda", checksum=checksum, entity_type='item',
+            entity_id=item_id, entity_name=item_name
+        ))
+        if group_name:
+            groups = {group_name: [item_name]}
+            self.session.add(DatapackageCache(
+                game="Zelda", checksum=checksum, entity_type='item_name_groups_json',
+                entity_id=0, entity_name=json.dumps(groups)
+            ))
+        self.session.commit()
+
+    def _add_notified_item(self, room, item_id, notified_id=1):
+        self.session.add(NotifiedItem(
+            id=notified_id,
+            room_id=room.room_id,
+            receiving_slot_id=1,
+            sending_slot_id=2,
+            item_id=item_id,
+            location_id=1000 + item_id,
+            item_index=0,
+            timestamp=datetime.now(timezone.utc)
+        ))
+        self.session.commit()
+
+    def _get_item_history(self, user, room_db_id):
+        token = self._generate_token(user.id)
+        headers = {'Authorization': f'Bearer {token}'}
+        res = self.client.get(f'/rooms/{room_db_id}/history/items', headers=headers)
+        self.assertEqual(res.status_code, 200)
+        return res.get_json()
+
+    def test_group_ignore_is_reflected_in_history(self):
+        room, user = self._make_room_and_user(checksum="checksumA")
+        self._add_item_datapackage("checksumA", item_id=501, item_name="Boo Buddy", group_name="Boos")
+        self._add_notified_item(room, item_id=501)
+
+        self.session.add(UserIgnoreItem(
+            user_id=user.id, item_name="Boos", game_name="Zelda", is_group=True
+        ))
+        self.session.commit()
+
+        history = self._get_item_history(user, room.id)
+        self.assertEqual(len(history), 1)
+        self.assertTrue(history[0]['isIgnored'], "Group-ignored item should be flagged isIgnored in history")
+        self.assertFalse(history[0]['isWhitelisted'])
+
+    def test_single_item_ignore_is_reflected_in_history(self):
+        room, user = self._make_room_and_user(checksum="checksumA")
+        self._add_item_datapackage("checksumA", item_id=502, item_name="Power Star")
+        self._add_notified_item(room, item_id=502)
+
+        self.session.add(UserIgnoreItem(
+            user_id=user.id, item_name="Power Star", game_name="Zelda", is_group=False
+        ))
+        self.session.commit()
+
+        history = self._get_item_history(user, room.id)
+        self.assertEqual(len(history), 1)
+        self.assertTrue(history[0]['isIgnored'])
+
+    def test_whitelist_overrides_group_ignore(self):
+        room, user = self._make_room_and_user(checksum="checksumA")
+        self._add_item_datapackage("checksumA", item_id=503, item_name="Boo Buddy", group_name="Boos")
+        self._add_notified_item(room, item_id=503)
+
+        self.session.add(UserIgnoreItem(
+            user_id=user.id, item_name="Boos", game_name="Zelda", is_group=True
+        ))
+        self.session.add(UserWhitelistItem(
+            user_id=user.id, item_name="Boo Buddy", game_name="Zelda", is_group=False
+        ))
+        self.session.commit()
+
+        history = self._get_item_history(user, room.id)
+        self.assertEqual(len(history), 1)
+        self.assertTrue(history[0]['isWhitelisted'])
+        self.assertFalse(history[0]['isIgnored'])
+
+    def test_group_ignore_does_not_leak_to_other_game(self):
+        room, user = self._make_room_and_user(checksum="checksumA")
+        self._add_item_datapackage("checksumA", item_id=504, item_name="Boo Buddy", group_name="Boos")
+        self._add_notified_item(room, item_id=504)
+
+        # Rule targets a different game entirely; should not match.
+        self.session.add(UserIgnoreItem(
+            user_id=user.id, item_name="Boos", game_name="Some Other Game", is_group=True
+        ))
+        self.session.commit()
+
+        history = self._get_item_history(user, room.id)
+        self.assertEqual(len(history), 1)
+        self.assertFalse(history[0]['isIgnored'])
+
+    def test_group_ignore_is_version_specific_to_checksum(self):
+        """
+        If the currently-cached datapackage version for a game has no group data
+        for the checksum in play (e.g. a different/older version), a group rule
+        for that game must not match items under that checksum.
+        """
+        room, user = self._make_room_and_user(checksum="checksumB")
+        # Item exists under checksumB, but with no item_name_groups_json entry
+        # (simulating a version where group data wasn't captured/available).
+        self._add_item_datapackage("checksumB", item_id=505, item_name="Boo Buddy", group_name=None)
+        self._add_notified_item(room, item_id=505)
+
+        self.session.add(UserIgnoreItem(
+            user_id=user.id, item_name="Boos", game_name="Zelda", is_group=True
+        ))
+        self.session.commit()
+
+        history = self._get_item_history(user, room.id)
+        self.assertEqual(len(history), 1)
+        self.assertFalse(history[0]['isIgnored'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Investigated a user theory that ignore/whitelist rules could break across
different versions (datapackage checksums) of the same game. That's not the
core issue for single-item rules (they're matched by name, which is
version-tolerant by design), but it **is** the root cause for item-group
rules specifically, and there was a second, more direct bug behind the
"group ignore doesn't hide items in history" reports.

- **Root cause of the user reports:** `HistoryScreen.kt`'s ignore/whitelist
  filtering ran entirely client-side by matching item *names*. Item-group
  membership isn't known to the client at all, so a group ignore rule (e.g.
  ignoring the "Boos" group) matched nothing in history, even though it
  correctly suppressed push notifications server-side (the poller already
  resolves groups against the datapackage). A `HintEntity` filter bug also
  ignored a rule's `gameName` scope entirely, applying it across all games.
- **Fix:** move ignore/whitelist evaluation server-side. Extracted the
  poller's matching logic (name/wildcard rules + checksum-scoped item-group
  resolution) into `backend/app/services/filtering_service.py`, used by both
  the poller and the history/hint endpoints. Endpoints now return
  `isIgnored`/`isWhitelisted` per item/hint, computed against the datapackage
  checksum in effect when the item was actually received — so item-group
  rules are now correctly scoped to the game version that was live, closing
  the version-mismatch gap the user's theory identified.
- The Android client now reads these fields directly instead of
  re-implementing the matching logic locally (~150 lines removed from
  `HistoryScreen.kt`). Room DB bumped to v22 with an additive migration for
  the two new columns.

**Known tradeoff:** flags are computed at sync time and cached locally, so
editing an ignore/whitelist rule affects new items going forward but won't
retroactively re-tag already-synced history rows until they resync.

## Test plan
- [x] `backend/tests/test_history_ignore_filtering.py` (new): group ignore,
      single-item ignore, whitelist-overrides-ignore, cross-game isolation,
      and checksum-version-specific group resolution
- [x] Full backend suite passes (`test_history_sync_cursor`,
      `test_threshold_reconciliation`, `test_whats_new`, plus the two
      pre-existing local-env-only failures unrelated to this change)
- [x] `:app:compileDevDebugKotlin` builds clean, no new warnings
- [ ] Manual smoke test on device: add a group ignore rule, receive/backfill
      an item in that group, confirm it's hidden from history with "Show
      ignored items" off and reappears with it on

🤖 Generated with [Claude Code](https://claude.com/claude-code)