### PR TITLE
Fix back navigation from slot history to slot detail

### DIFF
--- a/android/app/src/main/java/com/jones/aptracker/ui/ActivityFeedScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/ActivityFeedScreen.kt
@@ -4,9 +4,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -16,10 +24,33 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 fun ActivityFeedScreen(
     historyViewModel: HistoryViewModel = viewModel(),
     userViewModel: UserViewModel = viewModel(),
-    onNavigateToSlotDetail: ((Int, Int) -> Unit)? = null
+    onNavigateToSlotDetail: ((Int, Int) -> Unit)? = null,
+    onBackClick: (() -> Unit)? = null
 ) {
     Scaffold(
-        contentWindowInsets = WindowInsets(0.dp)
+        contentWindowInsets = WindowInsets(0.dp),
+        topBar = {
+            // Only shown when this screen is pushed as its own destination (e.g. from
+            // SlotDetailScreen). Embedded in the Activity bottom-nav tab, MainScreen owns the bar.
+            if (onBackClick != null) {
+                val historyFilter by historyViewModel.historyFilter.collectAsState()
+                val roomNames by historyViewModel.roomNames.collectAsState()
+                val titleText = when (val filter = historyFilter) {
+                    HistoryFilter.Active -> "Active Rooms"
+                    HistoryFilter.Archived -> "Archived Rooms"
+                    HistoryFilter.All -> "All History"
+                    is HistoryFilter.Specific -> roomNames[filter.roomId] ?: "Room History"
+                }
+                TopAppBar(
+                    title = { Text(titleText) },
+                    navigationIcon = {
+                        IconButton(onClick = onBackClick) {
+                            Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                        }
+                    }
+                )
+            }
+        }
     ) { innerPadding ->
         Column(
             modifier = Modifier

--- a/android/app/src/main/java/com/jones/aptracker/ui/AppNavigation.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/AppNavigation.kt
@@ -253,9 +253,19 @@ fun MainNavHost(
                 onBackClick = { navController.popBackStack() },
                 onNavigateToHistory = { roomId, _, query, player ->
                     historyViewModel.loadHistoryFor(roomId, query, player)
-                    historyViewModel.triggerNavigateToActivity()
-                    navController.popBackStack("home", inclusive = false)
+                    navController.navigate("slot_history")
                 }
+            )
+        }
+
+        composable("slot_history") {
+            ActivityFeedScreen(
+                historyViewModel = historyViewModel,
+                userViewModel = userViewModel,
+                onNavigateToSlotDetail = { roomDbId, slotId ->
+                    navController.navigate("slot_detail/$roomDbId/$slotId")
+                },
+                onBackClick = { navController.popBackStack() }
             )
         }
     }

--- a/android/app/src/main/java/com/jones/aptracker/ui/HistoryViewModel.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/HistoryViewModel.kt
@@ -249,17 +249,6 @@ class HistoryViewModel(application: Application) : AndroidViewModel(application)
     private val _actionMessage = MutableStateFlow<String?>(null)
     val actionMessage: StateFlow<String?> = _actionMessage
 
-    private val _pendingNavigateToActivity = MutableStateFlow(false)
-    val pendingNavigateToActivity: StateFlow<Boolean> = _pendingNavigateToActivity
-
-    fun triggerNavigateToActivity() {
-        _pendingNavigateToActivity.value = true
-    }
-
-    fun clearPendingNavigateToActivity() {
-        _pendingNavigateToActivity.value = false
-    }
-
     init {
         val apiService = RetrofitClient.instance
         repository = HistoryRepository.getInstance(application)

--- a/android/app/src/main/java/com/jones/aptracker/ui/MainScreen.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/MainScreen.kt
@@ -87,18 +87,6 @@ fun MainScreen(
 
     val historyFilter by historyViewModel.historyFilter.collectAsState()
     val roomNames by historyViewModel.roomNames.collectAsState()
-    val pendingNavigateToActivity by historyViewModel.pendingNavigateToActivity.collectAsState()
-
-    LaunchedEffect(pendingNavigateToActivity) {
-        if (pendingNavigateToActivity) {
-            bottomNavController.navigate(BottomNavItem.Activity.route) {
-                popUpTo(bottomNavController.graph.findStartDestination().id) { saveState = true }
-                launchSingleTop = true
-                restoreState = true
-            }
-            historyViewModel.clearPendingNavigateToActivity()
-        }
-    }
 
     // --- 1. Get URI Handler for links ---
     val uriHandler = LocalUriHandler.current


### PR DESCRIPTION
## Summary
- Fixes a reported bug: Slots → choose slot → View History → back landed on the main Rooms screen instead of returning to SlotDetail.
- Root cause: `onNavigateToHistory` in `AppNavigation.kt` popped the outer nav stack back to `home` and switched the Activity bottom-nav tab, which discarded the `slot_detail` back-stack entry.
- Fix: push a new `slot_history` outer destination on top of `slot_detail` instead. `ActivityFeedScreen` gains an optional `onBackClick` so it can render its own top bar (with the same title logic MainScreen used) when pushed this way; it's unchanged when embedded in the Activity bottom-nav tab.
- Removed the now-unused `pendingNavigateToActivity` plumbing (`HistoryViewModel`, `MainScreen`) that only existed to drive the old flow.

## Test plan
- [x] `./gradlew :app:compileDevDebugKotlin` builds successfully
- [x] On-device: Slots → tap a slot → View History → back → returns to SlotDetail → back → returns to Slots tab
- [x] Rooms tab → tap a room → still switches to Activity tab and back returns to Rooms (unchanged flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)