### PR TITLE
fix(activity-feed): paint cached history before waiting on network call

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -21,6 +21,7 @@ _Item Group Filtering Fixes & Cleaner Ignore Menu_
 > **Fixes**
 > • **Item Group Filtering**: Ignoring or whitelisting an item *group* now actually hides/shows those items in your History — previously these rules were silently ignored there.
 > • **Hint Filtering**: Hints now correctly respect per-game ignore/whitelist rules instead of applying them across every game.
+> • **Faster Activity Feed**: The Activity feed now loads instantly from your synced history instead of waiting on a network call first.
 >
 > **Improvements**
 > • **Cleaner Ignore/Whitelist Menu**: The item detail sheet now uses two simple "Whitelist..." / "Ignore..." buttons that expand into the full options, instead of a wall of buttons.
@@ -34,6 +35,8 @@ _Item Group Filtering Fixes & Cleaner Ignore Menu_
 > Fixed: ignoring or whitelisting an item group now actually hides/shows those items in History and hints (previously had no effect there). Hint filtering also now respects per-game rules instead of applying across every game.
 >
 > Improved: the whitelist/ignore menu on item details is now two simple buttons instead of a long list.
+>
+> Fixed: the Activity feed now loads your synced history instantly instead of waiting on a network call first.
 > ```
 
 > **GitHub Release Copy-Paste:**
@@ -41,6 +44,7 @@ _Item Group Filtering Fixes & Cleaner Ignore Menu_
 > ### Fixed
 > - **Item Group Ignore/Whitelist Filtering**: Item-group ignore/whitelist rules are now computed server-side (`filtering_service.py`) and returned per item/hint via `isIgnored`/`isWhitelisted` fields, fixing group rules having no effect in the History "Show ignored items" filter.
 > - **Hint Filtering Game Scope**: Hint filtering now correctly respects the game-specific scope of ignore/whitelist rules instead of applying them across all games.
+> - **Activity Feed Warm-Load Stall**: `HistoryViewModel.refreshAllHistory()` now paints from the local DB immediately when tracked-slot metadata from a prior load is already in memory, instead of blocking on `getUserTrackedSlots()` first — removing a 1-2s stall on every tab/room transition. First load in a session is unaffected since there's no warm metadata yet.
 >
 > ### Changed
 > - **Consolidated Ignore/Whitelist Menu**: The History item detail sheet's 6+ whitelist/ignore action buttons are now collapsed into two entry buttons that expand in-place to the scoped options.
@@ -52,6 +56,7 @@ _Item Group Filtering Fixes & Cleaner Ignore Menu_
 ### Fixed
 - **Item Group Ignore/Whitelist Now Applies in History**: Ignoring or whitelisting an item group now correctly hides or shows those items in your History; previously group-based rules had no effect there.
 - **Hint Filtering Respects Per-Game Rules**: Hints now correctly honor game-specific ignore/whitelist rules instead of applying them across all your games.
+- **Faster Activity Feed Loads**: The Activity feed now shows your synced history right away instead of waiting on a network call first, so switching to it feels instant.
 
 ---
 

--- a/backend/app/data/changelog.json
+++ b/backend/app/data/changelog.json
@@ -18,6 +18,10 @@
         {
           "title": "Cleaner Whitelist & Ignore Menu",
           "description": "The whitelist and ignore options on an item's detail screen are now two simple buttons that expand into the full set of choices, instead of a long wall of buttons."
+        },
+        {
+          "title": "Faster Activity Feed Loads",
+          "description": "The Activity feed now shows your synced history right away instead of waiting on a network call first, so switching to it feels instant."
         }
       ],
       "categories": {
@@ -36,13 +40,17 @@
           {
             "title": "Hint Filtering Respects Per-Game Rules",
             "description": "Hints now correctly honor game-specific ignore/whitelist rules instead of applying them across all your games."
+          },
+          {
+            "title": "Faster Activity Feed Loads",
+            "description": "The Activity feed now shows your synced history right away instead of waiting on a network call first, so switching to it feels instant."
           }
         ]
       },
       "release_notes": {
-        "discord": "**Archipelago Alerts Android App v1.6.23 Released!**\n\n**Fixes**\n• **Item Group Filtering**: Ignoring or whitelisting an item *group* now actually hides/shows those items in your History — previously these rules were silently ignored there.\n• **Hint Filtering**: Hints now correctly respect per-game ignore/whitelist rules instead of applying them across every game.\n\n**Improvements**\n• **Cleaner Ignore/Whitelist Menu**: The item detail sheet now uses two simple \"Whitelist...\" / \"Ignore...\" buttons that expand into the full options, instead of a wall of buttons.\n\nGitHub: <https://github.com/wrjones104/ap-tracker/releases/latest>\nPlay Store: <https://play.google.com/store/apps/details?id=com.jones.aptracker>",
-        "play_store": "Fixed: ignoring or whitelisting an item group now actually hides/shows those items in History and hints (previously had no effect there). Hint filtering also now respects per-game rules instead of applying across every game.\n\nImproved: the whitelist/ignore menu on item details is now two simple buttons instead of a long list.",
-        "github": "### Fixed\n- **Item Group Ignore/Whitelist Filtering**: Item-group ignore/whitelist rules are now computed server-side (`filtering_service.py`) and returned per item/hint via `isIgnored`/`isWhitelisted` fields, fixing group rules having no effect in the History \"Show ignored items\" filter.\n- **Hint Filtering Game Scope**: Hint filtering now correctly respects the game-specific scope of ignore/whitelist rules instead of applying them across all games.\n\n### Changed\n- **Consolidated Ignore/Whitelist Menu**: The History item detail sheet's 6+ whitelist/ignore action buttons are now collapsed into two entry buttons that expand in-place to the scoped options."
+        "discord": "**Archipelago Alerts Android App v1.6.23 Released!**\n\n**Fixes**\n• **Item Group Filtering**: Ignoring or whitelisting an item *group* now actually hides/shows those items in your History — previously these rules were silently ignored there.\n• **Hint Filtering**: Hints now correctly respect per-game ignore/whitelist rules instead of applying them across every game.\n• **Faster Activity Feed**: The Activity feed now loads instantly from your synced history instead of waiting on a network call first.\n\n**Improvements**\n• **Cleaner Ignore/Whitelist Menu**: The item detail sheet now uses two simple \"Whitelist...\" / \"Ignore...\" buttons that expand into the full options, instead of a wall of buttons.\n\nGitHub: <https://github.com/wrjones104/ap-tracker/releases/latest>\nPlay Store: <https://play.google.com/store/apps/details?id=com.jones.aptracker>",
+        "play_store": "Fixed: ignoring or whitelisting an item group now actually hides/shows those items in History and hints (previously had no effect there). Hint filtering also now respects per-game rules instead of applying across every game.\n\nImproved: the whitelist/ignore menu on item details is now two simple buttons instead of a long list.\n\nFixed: the Activity feed now loads your synced history instantly instead of waiting on a network call first.",
+        "github": "### Fixed\n- **Item Group Ignore/Whitelist Filtering**: Item-group ignore/whitelist rules are now computed server-side (`filtering_service.py`) and returned per item/hint via `isIgnored`/`isWhitelisted` fields, fixing group rules having no effect in the History \"Show ignored items\" filter.\n- **Hint Filtering Game Scope**: Hint filtering now correctly respects the game-specific scope of ignore/whitelist rules instead of applying them across all games.\n- **Activity Feed Warm-Load Stall**: `HistoryViewModel.refreshAllHistory()` now paints from the local DB immediately when tracked-slot metadata from a prior load is already in memory, instead of blocking on `getUserTrackedSlots()` first — removing a 1-2s stall on every tab/room transition. First load in a session is unaffected since there's no warm metadata yet.\n\n### Changed\n- **Consolidated Ignore/Whitelist Menu**: The History item detail sheet's 6+ whitelist/ignore action buttons are now collapsed into two entry buttons that expand in-place to the scoped options."
       }
     },
     {


### PR DESCRIPTION
## Summary
- Navigating to the Activity feed blocked on `getUserTrackedSlots()` before reading already-synced local history, adding a 1-2s stall to every transition even though the data was on-device.
- `HistoryViewModel.refreshAllHistory()` now paints from the local DB immediately when tracked-slot metadata from a prior load is already in memory, then reconciles silently once the network call returns. First-ever load in a session is unaffected since there's no warm metadata yet to paint from.
- Folded this fix into the still-unpublished v1.6.23 changelog entry (`backend/app/data/changelog.json`) alongside the item-group filtering/ignore-menu changes, and regenerated `android/CHANGELOG.md` / `backend/CHANGELOG.md`.

## Test plan
- [ ] Manually verify: open Activity feed from Rooms, SlotDetail, and the bottom nav tab after a warm session — history should paint instantly with no spinner stall.
- [ ] Manually verify: first load in a fresh session (no warm metadata) still works and shows a brief loading state as before.
- [ ] `python scripts/generate_changelog.py --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)