### PR TITLE
fix(whats-new): fix in-app What's New sheet returning fallback content

### DIFF
--- a/android/app/src/main/java/com/jones/aptracker/network/ApiService.kt
+++ b/android/app/src/main/java/com/jones/aptracker/network/ApiService.kt
@@ -222,12 +222,12 @@ interface ApiService {
     @POST("users/me/test-notification")
     suspend fun sendTestNotification(): Response<Unit>
 
-    @GET("whats_new")
+    @GET("api/whats_new")
     suspend fun getWhatsNew(
         @Query("target") target: String = "app"
     ): WhatsNewResponse
 
-    @GET("whats_new/latest")
+    @GET("api/whats_new/latest")
     suspend fun getLatestRelease(
         @Query("version") version: String? = null,
         @Query("target") target: String = "app"

--- a/android/app/src/main/java/com/jones/aptracker/network/WhatsNewModels.kt
+++ b/android/app/src/main/java/com/jones/aptracker/network/WhatsNewModels.kt
@@ -17,7 +17,7 @@ data class ReleaseInfo(
     val version: String,
     @SerializedName("release_date") val releaseDate: String? = null,
     val title: String? = null,
-    val highlights: List<String>? = null,
+    val highlights: List<CategoryItem>? = null,
     val categories: ReleaseCategories? = null,
     @SerializedName("discord_md") val discordMd: String? = null
 )

--- a/android/app/src/main/java/com/jones/aptracker/ui/WhatsNewBottomSheet.kt
+++ b/android/app/src/main/java/com/jones/aptracker/ui/WhatsNewBottomSheet.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.jones.aptracker.network.CategoryItem
 import com.jones.aptracker.network.ReleaseInfo
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -66,9 +67,18 @@ fun WhatsNewBottomSheet(
 
 
             val highlights = releaseInfo?.highlights ?: listOf(
-                "Cheese Tracker Notes & Status: View and edit your Cheese Tracker notes and status (Unknown, Unblocked, BK, Soft BK, Go Mode) right from a slot's detail screen.",
-                "\"Still BK\" Button: Keep your BK/Soft BK status while refreshing your Last Checked time, matching the Cheese Tracker web feature.",
-                "Ping Preferences: Set per-slot ping preferences, plus a default ping applied to newly claimed slots from the Profile screen."
+                CategoryItem(
+                    "Cheese Tracker Notes & Status",
+                    "View and edit your Cheese Tracker notes and status (Unknown, Unblocked, BK, Soft BK, Go Mode) right from a slot's detail screen."
+                ),
+                CategoryItem(
+                    "\"Still BK\" Button",
+                    "Keep your BK/Soft BK status while refreshing your Last Checked time, matching the Cheese Tracker web feature."
+                ),
+                CategoryItem(
+                    "Ping Preferences",
+                    "Set per-slot ping preferences, plus a default ping applied to newly claimed slots from the Profile screen."
+                )
             )
 
             // Highlights
@@ -104,11 +114,19 @@ fun WhatsNewBottomSheet(
                                 modifier = Modifier.size(14.dp)
                             )
                         }
-                        Text(
-                            text = highlight,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
+                        Column {
+                            Text(
+                                text = highlight.title,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = highlight.description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- The in-app "What's New" bottom sheet always showed hardcoded placeholder highlights instead of real release notes, for two independent reasons:
  - `ApiService`'s `whats_new` endpoints used bare paths (`whats_new/latest`) matching the rest of the app's Retrofit convention, but the backend registers those two routes under an explicit `/api/` prefix (`whats_new_routes.py`), unlike every other blueprint — every request 404'd.
  - `ReleaseInfo.highlights` was typed `List<String>`, but the backend has sent structured `{title, description}` objects for several releases now — even a successful response would have failed Gson parsing.
- Both failures were swallowed by the existing `catch` block in `AppNavigation.kt`, so the sheet silently fell back to its bundled default content with no visible error, no matter how up-to-date `changelog.json` was.
- Fixed by prefixing the two Retrofit paths with `api/` and retyping `highlights` as `List<CategoryItem>`, updating `WhatsNewBottomSheet.kt` to render title + description pairs (including the offline fallback content).

## Test plan
- [x] `./gradlew compileDevDebugKotlin` succeeds.
- [x] Verified locally against the dev container: `curl http://localhost:5000/api/whats_new/latest` returns 200 with real highlights; `curl http://localhost:5000/whats_new/latest` (the old path) returns 404, confirming the root cause.
- [x] Rebuilt on emulator (devDebug, storage cleared) — sheet now shows the real v1.6.23 highlights instead of the hardcoded Cheese Tracker placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)